### PR TITLE
Replace superblocks_agent_environment with superblocks_agent_tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,20 @@ container_max_capacity = 10
 #### Other Configurable Options
 
 ```terraform
-variable "superblocks_agent_environment" {
+variable "superblocks_agent_tags" {
   type        = string
-  default     = "*"
-  description = "Use this varible to differentiate Superblocks Agent running environment. Valid values are '*', 'staging' and 'production'"
+  default     = "profile:*"
+  description = <<EOF
+    Use this variable to specify which profile-specific workloads can be executed on this agent.
+    It accepts a comma (and colon) separated string representing key-value pairs, and currently only the "profile" key is used.
+
+    Some examples:
+    - To support all API executions:      "profile:*"
+    - To support staging and production:  "profile:staging,profile:production"
+    - To support only staging:            "profile:staging"
+    - To support only production:         "profile:production"
+    - To support a custom profile:        "profile:custom_profile_key"
+  EOF
 }
 
 variable "superblocks_agent_image" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -113,7 +113,7 @@ module "ecs" {
       { "name": "SUPERBLOCKS_AGENT_KEY", "value": "${var.superblocks_agent_key}" },
       { "name": "SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED", "value": "false" },
       { "name": "SUPERBLOCKS_AGENT_HOST_URL", "value": "${local.agent_host_url}" },
-      { "name": "SUPERBLOCKS_AGENT_ENVIRONMENT", "value": "*" },
+      { "name": "SUPERBLOCKS_AGENT_TAGS", "value": "profile:*" },
       { "name": "SUPERBLOCKS_AGENT_PORT", "value": "8020" }
     ]
   ENV

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,13 @@
 data "aws_region" "current" {}
 
 locals {
-  # if superblocks_agent_tags is not default, then use superblocks_agent_tags as is
-  # if superblocks_agent_tags is default, then use profile:${superblocks_agent_environment} if superblocks_agent_environment is *, else use profile:${superblocks_agent_environment}
+  # if superblocks_agent_tags is not default, then
+  #   use superblocks_agent_tags as is
+  # else if superblocks_agent_tags is default, then
+  #   if superblocks_agent_environment is *,
+  #     use profile:* (default)
+  #   else
+  #     use profile:${superblocks_agent_environment}
   superblocks_agent_tags = var.superblocks_agent_tags != "profile:*" ? var.superblocks_agent_tags : var.superblocks_agent_environment == "*" ? "profile:*" : "profile:${var.superblocks_agent_environment}"
 
   tags = merge(var.tags, {

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,12 @@
 data "aws_region" "current" {}
 
 locals {
-  env = var.superblocks_agent_environment == "*" ? "any" : var.superblocks_agent_environment
+  # if superblocks_agent_tags is not default, then use superblocks_agent_tags as is
+  # if superblocks_agent_tags is default, then use profile:${superblocks_agent_environment} if superblocks_agent_environment is *, else use profile:${superblocks_agent_environment}
+  superblocks_agent_tags = var.superblocks_agent_tags != "profile:*" ? var.superblocks_agent_tags : var.superblocks_agent_environment == "*" ? "profile:*" : "profile:${var.superblocks_agent_environment}"
+
   tags = merge(var.tags, {
-    superblocks_agent_environment = local.env
+    superblocks_agent_tags = var.superblocks_agent_tags
   })
 
   region         = data.aws_region.current.name

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ module "ecs" {
       { "name": "SUPERBLOCKS_AGENT_KEY", "value": "${var.superblocks_agent_key}" },
       { "name": "SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED", "value": "false" },
       { "name": "SUPERBLOCKS_AGENT_HOST_URL", "value": "${local.agent_host_url}" },
+      { "name": "SUPERBLOCKS_AGENT_ENVIRONMENT", "value": "${local.superblocks_agent_environment}" },
       { "name": "SUPERBLOCKS_AGENT_TAGS", "value": "${local.superblocks_agent_tags}" },
       { "name": "SUPERBLOCKS_AGENT_PORT", "value": "${var.superblocks_agent_port}" },
       { "name": "SUPERBLOCKS_AGENT_DATA_DOMAIN", "value": "${var.superblocks_agent_data_domain}" },

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "ecs" {
       { "name": "SUPERBLOCKS_AGENT_KEY", "value": "${var.superblocks_agent_key}" },
       { "name": "SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED", "value": "false" },
       { "name": "SUPERBLOCKS_AGENT_HOST_URL", "value": "${local.agent_host_url}" },
-      { "name": "SUPERBLOCKS_AGENT_ENVIRONMENT", "value": "${var.superblocks_agent_environment}" },
+      { "name": "SUPERBLOCKS_AGENT_TAGS", "value": "${var.superblocks_agent_tags}" },
       { "name": "SUPERBLOCKS_AGENT_PORT", "value": "${var.superblocks_agent_port}" },
       { "name": "SUPERBLOCKS_AGENT_DATA_DOMAIN", "value": "${var.superblocks_agent_data_domain}" },
       { "name": "NODE_OPTIONS", "value": "--max_old_space_size=${local.node_heap}"}

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "ecs" {
       { "name": "SUPERBLOCKS_AGENT_KEY", "value": "${var.superblocks_agent_key}" },
       { "name": "SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED", "value": "false" },
       { "name": "SUPERBLOCKS_AGENT_HOST_URL", "value": "${local.agent_host_url}" },
-      { "name": "SUPERBLOCKS_AGENT_TAGS", "value": "${var.superblocks_agent_tags}" },
+      { "name": "SUPERBLOCKS_AGENT_TAGS", "value": "${local.superblocks_agent_tags}" },
       { "name": "SUPERBLOCKS_AGENT_PORT", "value": "${var.superblocks_agent_port}" },
       { "name": "SUPERBLOCKS_AGENT_DATA_DOMAIN", "value": "${var.superblocks_agent_data_domain}" },
       { "name": "NODE_OPTIONS", "value": "--max_old_space_size=${local.node_heap}"}

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ module "ecs" {
 
   container_port         = var.superblocks_agent_port
   container_image        = var.superblocks_agent_image
+  # SUPERBLOCKS_AGENT_ENVIRONMENT is being passed for backwards compatibility with older versions of the agent
   container_environment  = <<ENV
     [
       { "name": "__SUPERBLOCKS_AGENT_SERVER_URL", "value": "${var.superblocks_server_url}" },

--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,25 @@ variable "superblocks_agent_environment" {
   type        = string
   default     = "*"
   description = <<EOF
+    DEPRECATED! Use superblocks_agent_tags instead.
     Use this varible to differentiate Superblocks Agent running environment.
     Valid values are "*", "staging" and "production"
+  EOF
+}
+
+variable "superblocks_agent_tags" {
+  type        = string
+  default     = "profile:*"
+  description = <<EOF
+    Use this variable to specify which profile-specific workloads can be executed on this agent.
+    It accepts a comma (and colon) separated string representing key-value pairs, and currently only the "profile" key is used.
+
+    Some examples:
+    - To support all API executions:      "profile:*"
+    - To support staging and production:  "profile:staging,profile:production"
+    - To support only staging:            "profile:staging"
+    - To support only production:         "profile:production"
+    - To support a custom profile:        "profile:custom_profile_key"
   EOF
 }
 


### PR DESCRIPTION
Note that I'm keeping around superblocks_agent_environment as an undocumented variable and leveraging it conditionally to make this a non breaking change for existing users.

if you look at locals, the order of precedence is:

- if superblocks_agent_tags is not the default value, use it.
- if superblocks_agent_tags is the default value, check superblocks_agent_environment
    - if superblocks_agent_environment is not default value, set superblocks_agent_tags to `profile:${var.superblocks_agent_environment}`
    - else use `profile:*` (default)
