### PR TITLE
Update the container environment variable SUPERBLOCKS_AGENT_ENVIRONMENT value.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ module "ecs" {
       { "name": "SUPERBLOCKS_AGENT_KEY", "value": "${var.superblocks_agent_key}" },
       { "name": "SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED", "value": "false" },
       { "name": "SUPERBLOCKS_AGENT_HOST_URL", "value": "${local.agent_host_url}" },
-      { "name": "SUPERBLOCKS_AGENT_ENVIRONMENT", "value": "${local.superblocks_agent_environment}" },
+      { "name": "SUPERBLOCKS_AGENT_ENVIRONMENT", "value": "${local.superblocks_agent_tags}" },
       { "name": "SUPERBLOCKS_AGENT_TAGS", "value": "${local.superblocks_agent_tags}" },
       { "name": "SUPERBLOCKS_AGENT_PORT", "value": "${var.superblocks_agent_port}" },
       { "name": "SUPERBLOCKS_AGENT_DATA_DOMAIN", "value": "${var.superblocks_agent_data_domain}" },


### PR DESCRIPTION
local.superblocks_agent_environment no longer exists. I am getting the following error when running plan.

![image](https://github.com/superblocksteam/terraform-aws-superblocks/assets/16090401/d7208c88-8dfa-4fb4-874e-ee4e3515f69b)

There's a logic in the local.tf file that sets local.superblocks_agent_tags to the correct value while considering the value of the old local.superblocks_agent_environment. I am assuming that there's a use case where a customer would use an older version of the container agent but this version of terraform module; therefore, this variable needs to be kept for the older version of the container image to use. In that case, the environment variable value should be set to local.superblocks_agent_tags.

