### PR TITLE
Support for adding policies to ECS Task Execution Role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,8 @@ module "ecs" {
   security_group_ids = var.ecs_security_group_ids
   target_group_arns  = local.lb_target_group_arns
 
-  task_role_arn = var.superblocks_agent_role_arn
+  additional_ecs_execution_task_policy_arns = var.additional_ecs_execution_task_policy_arns
+  task_role_arn                             = var.superblocks_agent_role_arn
 
   container_port  = local.superblocks_http_port
   container_image = var.superblocks_agent_image

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -97,8 +97,6 @@ resource "aws_iam_role" "superblocks_agent_role" {
 }
 EOF
 
-  managed_policy_arns = concat([aws_iam_policy.superblocks_agent_policy.arn], var.additional_ecs_execution_task_policy_arns)
-
   tags = var.tags
 }
 
@@ -122,6 +120,14 @@ resource "aws_iam_policy" "superblocks_agent_policy" {
 EOF
 
   tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "superblocks_agent_policy_attachment" {
+  for_each = toset(
+    concat([aws_iam_policy.superblocks_agent_policy.arn], var.additional_ecs_execution_task_policy_arns)
+  )
+  role       = aws_iam_role.superblocks_agent_role.name
+  policy_arn = each.value
 }
 
 ####################################################################

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,3 +1,7 @@
+locals {
+  policies = concat([aws_iam_policy.superblocks_agent_policy.arn], var.additional_ecs_execution_task_policy_arns)
+}
+
 resource "aws_ecs_cluster" "superblocks" {
   name = "${var.name_prefix}-cluster"
   setting {
@@ -123,11 +127,9 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "superblocks_agent_policy_attachment" {
-  for_each = toset(
-    concat([aws_iam_policy.superblocks_agent_policy.arn], var.additional_ecs_execution_task_policy_arns)
-  )
+  count      = length(local.policies)
   role       = aws_iam_role.superblocks_agent_role.name
-  policy_arn = each.value
+  policy_arn = local.policies[count.index]
 }
 
 ####################################################################

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "superblocks_agent" {
 }
 
 ####################################################################
-# ECS Task Role
+# ECS Task Execution Role
 ####################################################################
 resource "aws_iam_role" "superblocks_agent_role" {
   name_prefix        = "${var.name_prefix}-agent-role"
@@ -96,6 +96,8 @@ resource "aws_iam_role" "superblocks_agent_role" {
   ]
 }
 EOF
+
+  managed_policy_arns = concat([aws_iam_policy.superblocks_agent_policy.arn], var.additional_ecs_execution_task_policy_arns)
 
   tags = var.tags
 }
@@ -120,11 +122,6 @@ resource "aws_iam_policy" "superblocks_agent_policy" {
 EOF
 
   tags = var.tags
-}
-
-resource "aws_iam_role_policy_attachment" "policy-attach" {
-  role       = aws_iam_role.superblocks_agent_role.name
-  policy_arn = aws_iam_policy.superblocks_agent_policy.arn
 }
 
 ####################################################################

--- a/modules/ecs/output.tf
+++ b/modules/ecs/output.tf
@@ -1,3 +1,8 @@
 output "ecs_security_group_id" {
   value = var.create_sg ? module.ecs_security_group[0].security_group_id : null
 }
+
+# The execution agent role
+output "superblocks_agent_role" {
+  value = aws_iam_role.superblocks_agent_role
+}

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -117,3 +117,9 @@ variable "sg_egress_with_cidr_blocks" {
     }
   ]
 }
+
+variable "additional_ecs_execution_task_policy_arns" {
+  type        = list(string)
+  default     = []
+  description = "List of ARNs of Additional iam policy to attach to the ECS execution role"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,3 +25,8 @@ output "lb_dns_name" {
 output "agent_host_url" {
   value = local.agent_host_url
 }
+
+# The ecs execution agent role
+output "ecs_execution_agent_role" {
+  value = module.ecs.superblocks_agent_role
+}

--- a/variables.tf
+++ b/variables.tf
@@ -328,3 +328,9 @@ variable "ecs_sg_egress_with_cidr_blocks" {
   ]
   description = "Specify egress rules for the ECS cluster. Only used if create_ecs_sg is set to true."
 }
+
+variable "additional_ecs_execution_task_policy_arns" {
+  type        = list(string)
+  default     = []
+  description = "List of ARNs of Additional iam policy to attach to the ECS execution role"
+}


### PR DESCRIPTION
Includes  fixes for the isssue:  _No way to easily add policies to the ECS Task Execution Role #19_

* Added support for adding additional IAM policies to the ECS Task Execution Role
  * Made `module.ecs.superblocks_agent_role` an output of ecs and top level modules
  * Added parameter to pass in an array of policy ARNs that would be attached to the ECS Task Execution Role
* Updated README.md
  * Added section on ECS Task Roles 
      * Explained the difference between the two roles 
      * Examples for ECS Task Execution Role 
      * Example for creating and using the  ECS Task Role