### PR TITLE
Couple GRPC listener creation with presence of a certificate.

### DIFF
--- a/modules/load-balancer/main.tf
+++ b/modules/load-balancer/main.tf
@@ -24,6 +24,8 @@ resource "aws_lb_target_group" "http" {
 }
 
 resource "aws_lb_target_group" "grpc" {
+  count = var.certificate_arn != null ? 1 : 0
+
   name_prefix = substr(var.name_prefix, 0, 6)
   port        = var.container_port_grpc
   protocol    = "HTTP"
@@ -72,6 +74,8 @@ resource "aws_lb_listener" "superblocks" {
 }
 
 resource "aws_lb_listener" "grpc" {
+  count = var.certificate_arn != null ? 1 : 0
+
   load_balancer_arn = aws_lb.superblocks.arn
   port              = 8443
   protocol          = var.listener_protocol
@@ -81,7 +85,7 @@ resource "aws_lb_listener" "grpc" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.grpc.arn
+    target_group_arn = aws_lb_target_group.grpc[0].arn
   }
 }
 

--- a/modules/load-balancer/outputs.tf
+++ b/modules/load-balancer/outputs.tf
@@ -11,7 +11,7 @@ output "target_group_http_arn" {
 }
 
 output "target_group_grpc_arn" {
-  value = aws_lb_target_group.grpc.arn
+  value = try(aws_lb_target_group.grpc[0].arn, "")
 }
 
 output "lb_security_group_id" {


### PR DESCRIPTION
Internal load balancers may not be supplying a certificate which
prevents the GRPC listener from being created.
