### PR TITLE
feat(native-db): add modules/native-db — OPA runtime config for Fargate (ENG-4959)

### DIFF
--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -1,0 +1,83 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Bootstrap the IAM roles and S3 state bucket required before the OPA lifecycle
+# worker can provision RDS/Aurora instances. Run this once per region.
+# EKS customers only need this module — runtime config goes in the Helm chart.
+#
+# Registry path (when consuming from Terraform Registry):
+#   source  = "superblocksteam/superblocks/aws//modules/native-db-prereqs"
+#   version = "~>1.0"
+module "native_db_prereqs" {
+  source = "../../modules/native-db-prereqs"
+
+  deployment_type = "eks"
+  region          = "us-east-1"
+
+  # One entry per OPA deployment. The map key is the agent name — used to name
+  # IAM roles and must be unique per AWS account (max 15 characters).
+  agents = {
+    opa1 = {
+      # Agent tags namespace the DB users provisioned by this OPA.
+      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Must match the superblocks_agent_tags configured for this OPA.
+      agent_tags = ["nonprod", "production"]
+
+      # VPC the lifecycle worker is allowed to provision RDS/Aurora into.
+      vpc_id = "vpc-0123456789abcdef0"
+
+      # ARN of the EKS cluster's OIDC provider. Found in the EKS console under
+      # "Configuration > Authentication", or via:
+      #   aws eks describe-cluster --name <cluster-name> \
+      #     --query "cluster.identity.oidc.issuer" --output text
+      oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+
+      # Optional: Kubernetes namespace and service account name of the OPA pod.
+      # Used to scope the OIDC trust policy condition to the specific service account
+      # (system:serviceaccount:<namespace>:<service_account_name>). Defaults match
+      # the standard Superblocks Helm chart values — only override if you deviate.
+      # namespace            = "superblocks"
+      # service_account_name = "superblocks-agent"
+
+      # Optional: name of an existing IRSA role to attach lifecycle worker policies
+      # to. When omitted, the module creates a new role. Use this when your OPA pod
+      # already has an IRSA-annotated role from a prior Helm install (brownfield).
+      # The existing role's trust policy is left unchanged.
+      # existing_role_name = "my-existing-opa-irsa-role"
+
+      # Optional: ARN of a customer-managed KMS key used to encrypt the RDS-managed
+      # master secret in Secrets Manager. When omitted, the secret uses the AWS-managed
+      # Secrets Manager key for your account.
+      # rds_secret_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+    }
+
+    # Example: second OPA in the same region, different EKS cluster.
+    # opa2 = {
+    #   agent_tags        = ["staging"]
+    #   vpc_id            = "vpc-0fedcba9876543210"
+    #   oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE0987654321"
+    # }
+  }
+
+  # Optional: override the default resource name prefix ("sb-native-db").
+  # name_prefix = "acme-native-db"
+
+  # Optional: customer-managed KMS key for the OpenTofu state bucket.
+  # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+
+  # Optional: additional tags applied to all resources created by this module.
+  tags = {
+    Environment = "production"
+  }
+}
+
+output "agents" {
+  value       = module.native_db_prereqs.agents
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (annotate the OPA service account via eks.amazonaws.com/role-arn) and connector_role_arn (pass to OPA Helm chart as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "state_bucket_name" {
+  value       = module.native_db_prereqs.state_bucket_name
+  description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -74,6 +74,7 @@ module "native_db_opa1" {
   source = "../../modules/native-db"
 
   # Wired directly from native-db-prereqs outputs.
+  agent_name         = "opa1"
   connector_role_arn = module.native_db_prereqs.agents["opa1"].connector_role_arn
   agent_tags         = module.native_db_prereqs.agents["opa1"].agent_tags
   state_bucket_name  = module.native_db_prereqs.state_bucket_name

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -62,12 +62,64 @@ module "native_db_prereqs" {
   }
 }
 
+# Step 2 of 2: generate the environment variables the OPA ECS container needs
+# to run the lifecycle worker. Call this once per OPA. Pass ecs_env_vars as
+# superblocks_agent_environment_variables in the terraform-aws-superblocks root
+# module that manages the ECS task definition.
+#
+# Registry path (when consuming from Terraform Registry):
+#   source  = "superblocksteam/superblocks/aws//modules/native-db"
+#   version = "~>1.0"
+module "native_db_opa1" {
+  source = "../../modules/native-db"
+
+  # Wired directly from native-db-prereqs outputs.
+  connector_role_arn = module.native_db_prereqs.agents["opa1"].connector_role_arn
+  agent_tags         = module.native_db_prereqs.agents["opa1"].agent_tags
+  state_bucket_name  = module.native_db_prereqs.state_bucket_name
+
+  region = "us-east-1"
+
+  # Namespaces this OPA's OpenTofu state within the shared S3 bucket.
+  # Must be unique per OPA. Using the agent name as a suffix is recommended.
+  key_prefix = "native-db/opa1"
+
+  physical_module_inputs = {
+    instance_class    = "db.t4g.medium"
+    allocated_storage = 100
+
+    vpc_id = "vpc-0123456789abcdef0"
+
+    # Subnets in at least two Availability Zones — required by the DB subnet group.
+    subnet_ids = [
+      "subnet-0000000000000001",
+      "subnet-0000000000000002",
+    ]
+
+    # Propagate the same tags applied to IAM and S3 resources above.
+    tags = module.native_db_prereqs.tags
+
+    # Optional: restrict which security groups (e.g. your OPA task SG) can reach
+    # the RDS instances over port 5432.
+    # source_security_group_ids = ["sg-0123456789abcdef0"]
+  }
+
+  # Optional: override the pool capacity. Default is 100 logical databases per
+  # physical RDS instance before a new instance is automatically provisioned.
+  # pool = { max_databases = 50 }
+}
+
 output "agents" {
   value       = module.native_db_prereqs.agents
-  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (set as ECS task role ARN) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+  description = "Per-agent outputs: lifecycle_worker_role_arn (set as the ECS task role ARN), connector_role_arn, and agent_tags."
 }
 
 output "state_bucket_name" {
   value       = module.native_db_prereqs.state_bucket_name
   description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}
+
+output "opa1_ecs_env_vars" {
+  value       = module.native_db_opa1.ecs_env_vars
+  description = "Pass as superblocks_agent_environment_variables in the terraform-aws-superblocks root module for the opa1 ECS task definition."
 }

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -1,0 +1,73 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Step 1 of 2 for Fargate customers: bootstrap IAM roles and S3 state bucket.
+# Pass the outputs of this module into modules/native-db (step 2), which
+# generates the ecs_env_vars wired into the OPA ECS task definition.
+#
+# Registry path (when consuming from Terraform Registry):
+#   source  = "superblocksteam/superblocks/aws//modules/native-db-prereqs"
+#   version = "~>1.0"
+module "native_db_prereqs" {
+  source = "../../modules/native-db-prereqs"
+
+  deployment_type = "fargate"
+  region          = "us-east-1"
+
+  # One entry per OPA deployment. The map key is the agent name — used to name
+  # IAM roles and must be unique per AWS account (max 15 characters).
+  agents = {
+    opa1 = {
+      # Agent tags namespace the DB users provisioned by this OPA.
+      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Must match the superblocks_agent_tags configured for this OPA.
+      agent_tags = ["nonprod", "production"]
+
+      # VPC the lifecycle worker is allowed to provision RDS/Aurora into.
+      vpc_id = "vpc-0123456789abcdef0"
+
+      # Optional: name of an existing ECS task IAM role to attach lifecycle worker
+      # policies to. When omitted, the module creates a new role. Use this when
+      # your OPA ECS task already has a role you want to reuse (brownfield).
+      # existing_role_name = "my-existing-opa-task-role"
+
+      # Optional: ARN of a customer-managed KMS key used to encrypt the RDS-managed
+      # master secret in Secrets Manager. When omitted, the secret uses the AWS-managed
+      # Secrets Manager key for your account.
+      # rds_secret_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+    }
+
+    # Example: second OPA in the same region. No state_bucket_name wiring needed —
+    # all agents in this module invocation share the same S3 bucket automatically.
+    # opa2 = {
+    #   agent_tags = ["staging"]
+    #   vpc_id     = "vpc-0fedcba9876543210"
+    # }
+  }
+
+  # Optional: override the default resource name prefix ("sb-native-db").
+  # IAM roles are named <name_prefix>-<agent_name>-*; the S3 state bucket is
+  # named <name_prefix>-<region>-<account_id>.
+  # Max 16 characters. Only needed when your org enforces a naming convention.
+  # name_prefix = "acme-native-db"
+
+  # Optional: customer-managed KMS key for the OpenTofu state bucket.
+  # When omitted, the bucket uses AWS account-default encryption (SSE-S3).
+  # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+
+  # Optional: additional tags applied to all resources created by this module.
+  tags = {
+    Environment = "production"
+  }
+}
+
+output "agents" {
+  value       = module.native_db_prereqs.agents
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (set as ECS task role ARN) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "state_bucket_name" {
+  value       = module.native_db_prereqs.state_bucket_name
+  description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -1,0 +1,981 @@
+data "aws_caller_identity" "current" {}
+
+# Look up any existing roles customers provide so we can reference their ARNs.
+data "aws_iam_role" "existing" {
+  for_each = { for k, agent in var.agents : k => agent.existing_role_name if agent.existing_role_name != null }
+  name     = each.value
+}
+
+locals {
+  # ----------------------------------------------------------------
+  # Per-agent role resolution.
+  # When existing_role_name is set, use that role; otherwise use the
+  # role created by this module for that agent.
+  # ----------------------------------------------------------------
+  agent_role_names = {
+    for k, agent in var.agents : k =>
+    agent.existing_role_name != null
+    ? agent.existing_role_name
+    : aws_iam_role.lifecycle_worker[k].name
+  }
+
+  agent_role_arns = {
+    for k, agent in var.agents : k =>
+    agent.existing_role_name != null
+    ? data.aws_iam_role.existing[k].arn
+    : aws_iam_role.lifecycle_worker[k].arn
+  }
+
+  # ----------------------------------------------------------------
+  # Tagging
+  # ----------------------------------------------------------------
+  managed_by_tag = "superblocks-native-database-lifecycle"
+  tags           = merge(var.tags, { ManagedBy = local.managed_by_tag })
+
+  # ----------------------------------------------------------------
+  # RDS and EC2 ARN helpers (region + account scoped, not agent scoped)
+  # ----------------------------------------------------------------
+  rds_prefix = "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}"
+  ec2_prefix = "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}"
+
+  rds_resources = {
+    cluster          = "${local.rds_prefix}:cluster:sb-*"
+    cluster_pg       = "${local.rds_prefix}:cluster-pg:sb-*"
+    cluster_pg_all   = "${local.rds_prefix}:cluster-pg:*"
+    cluster_snapshot = "${local.rds_prefix}:cluster-snapshot:sb-*"
+    db               = "${local.rds_prefix}:db:sb-*"
+    pg_sb            = "${local.rds_prefix}:pg:sb-*"
+    pg_all           = "${local.rds_prefix}:pg:*"
+    snapshot         = "${local.rds_prefix}:snapshot:sb-*"
+    subgrp           = "${local.rds_prefix}:subgrp:sb-*"
+  }
+
+  # ----------------------------------------------------------------
+  # S3 state bucket ARN (always created, shared across all agents)
+  # ----------------------------------------------------------------
+  state_bucket_arn = aws_s3_bucket.tofu_state.arn
+
+  # ----------------------------------------------------------------
+  # KMS statement for the state bucket (module-level, one shared bucket).
+  # When a specific KMS key is provided the Resource is scoped to that key.
+  # When null, Resource is * but access is constrained via CalledVia.
+  # ----------------------------------------------------------------
+  state_bucket_kms_statement = merge(
+    {
+      Sid    = "StateBucketKms"
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncryptFrom",
+        "kms:ReEncryptTo",
+      ]
+      Resource = var.kms_key_arn != null ? var.kms_key_arn : "*"
+    },
+    var.kms_key_arn == null ? {
+      Condition = {
+        "ForAnyValue:StringEquals" = {
+          "aws:CalledVia" = "s3.amazonaws.com"
+        }
+      }
+    } : {}
+  )
+
+  # ----------------------------------------------------------------
+  # Per-agent OIDC provider URLs (EKS only).
+  # ARN format: arn:aws:iam::<account>:oidc-provider/<url>
+  # ----------------------------------------------------------------
+  oidc_provider_urls = {
+    for k, agent in var.agents : k =>
+    var.deployment_type == "eks"
+    ? replace(agent.oidc_provider_arn, "/^arn:aws:iam::[0-9]+:oidc-provider\\//", "")
+    : ""
+  }
+
+  # ----------------------------------------------------------------
+  # Per-agent trust policies for the lifecycle worker role.
+  # EKS uses OIDC web identity; Fargate uses ECS task service principal.
+  # ----------------------------------------------------------------
+  lifecycle_worker_assume_role_policies = {
+    for k, agent in var.agents : k =>
+    var.deployment_type == "eks" ? jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect    = "Allow"
+          Action    = "sts:AssumeRoleWithWebIdentity"
+          Principal = { Federated = agent.oidc_provider_arn }
+          Condition = {
+            StringEquals = {
+              "${local.oidc_provider_urls[k]}:aud" = "sts.amazonaws.com"
+            }
+            StringLike = {
+              "${local.oidc_provider_urls[k]}:sub" = "system:serviceaccount:${agent.namespace}:${agent.service_account_name}"
+            }
+          }
+        }
+      ]
+      }) : jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect    = "Allow"
+          Action    = "sts:AssumeRole"
+          Principal = { Service = "ecs-tasks.amazonaws.com" }
+        }
+      ]
+    })
+  }
+
+  # ----------------------------------------------------------------
+  # Per-agent EC2 VPC statement for CreateSecurityGroup.
+  # ec2:VpcID is a single-value condition key on the vpc/ resource type.
+  # ----------------------------------------------------------------
+  agent_ec2_create_sg_vpc_statements = {
+    for k, agent in var.agents : k => [
+      {
+        Sid      = "Ec2CreateSecurityGroupVpc${replace(agent.vpc_id, "-", "")}"
+        Effect   = "Allow"
+        Action   = ["ec2:CreateSecurityGroup"]
+        Resource = "${local.ec2_prefix}:vpc/${agent.vpc_id}"
+        Condition = {
+          StringEquals = {
+            "ec2:VpcID" = agent.vpc_id
+          }
+        }
+      }
+    ]
+  }
+
+  # ----------------------------------------------------------------
+  # Per-agent KMS statement for RDS-managed master secrets.
+  # When a CMK is provided: Resource is scoped to that key.
+  # When null: Resource is * (AWS-managed key path; ViaService + context still apply).
+  # ----------------------------------------------------------------
+  agent_rds_secret_kms_statements = {
+    for k, agent in var.agents : k => {
+      Sid      = "DecryptRdsManagedSecretKmsKey"
+      Effect   = "Allow"
+      Action   = ["kms:Decrypt", "kms:DescribeKey"]
+      Resource = agent.rds_secret_kms_key_arn != null ? agent.rds_secret_kms_key_arn : "*"
+      Condition = {
+        StringEquals = {
+          "kms:ViaService" = "secretsmanager.${var.region}.amazonaws.com"
+        }
+        StringLike = {
+          "kms:EncryptionContext:SecretARN" = [
+            "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+            "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+          ]
+        }
+      }
+    }
+  }
+}
+
+####################################################################
+# Lifecycle Worker IAM Role (one per agent, greenfield only)
+#
+# Skipped when existing_role_name is set for that agent — policies
+# are attached to the provided roles instead.
+####################################################################
+resource "aws_iam_role" "lifecycle_worker" {
+  for_each = { for k, agent in var.agents : k => agent if agent.existing_role_name == null }
+
+  name               = "${var.name_prefix}-${each.key}-lifecycle-worker-${var.region}"
+  assume_role_policy = local.lifecycle_worker_assume_role_policies[each.key]
+
+  tags = local.tags
+}
+
+# ----------------------------------------------------------------
+# Policy: assume the connector role
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_assume_connector" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-assume-connector"
+  description = "Allows the ${each.key} lifecycle worker to assume its connector role for RDS IAM authentication."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AssumeNativeDatabaseConnector"
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = [aws_iam_role.connector[each.key].arn]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_assume_connector" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_assume_connector[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: OpenTofu S3 state backend (shared bucket, per-agent policy)
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_state_bucket" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-state-bucket-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to read and write OpenTofu state in the shared S3 bucket."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "StateBucketList"
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:GetBucketVersioning",
+          "s3:ListBucket",
+        ]
+        Resource = local.state_bucket_arn
+      },
+      {
+        Sid    = "StateBucketObjectReadWrite"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+        ]
+        Resource = "${local.state_bucket_arn}/*"
+      },
+      local.state_bucket_kms_statement,
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_state_bucket" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_state_bucket[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: RDS provisioning — describe + create
+#
+# Create actions carry security-enforcing conditions:
+#   - ManageMasterUserPassword: master password stored in Secrets Manager
+#     automatically (no plaintext credentials in state).
+#   - PubliclyAccessible: instances must remain VPC-private.
+#   - ManagedBy + Vpc request tags: resources must be tagged at creation
+#     so subsequent mutating-action conditions can scope to them.
+# StorageEncrypted and DatabaseEngine are enforced via IAM condition keys on
+# create actions where AWS supports them (db* and cluster* resource types).
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-rds-provisioning-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to describe and provision RDS/Aurora instances and clusters."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RdsDescribe"
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeDBClusterParameterGroups",
+          "rds:DescribeDBClusterParameters",
+          "rds:DescribeDBClusterSnapshots",
+          "rds:DescribeDBClusters",
+          "rds:DescribeDBEngineVersions",
+          "rds:DescribeDBInstances",
+          "rds:DescribeDBParameterGroups",
+          "rds:DescribeDBParameters",
+          "rds:DescribeDBSnapshots",
+          "rds:DescribeDBSubnetGroups",
+          "rds:DescribeGlobalClusters",
+          "rds:DescribePendingMaintenanceActions",
+          "rds:ListTagsForResource",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "CreateRdsServiceLinkedRole"
+        Effect   = "Allow"
+        Action   = "iam:CreateServiceLinkedRole"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "iam:AWSServiceName" = "rds.amazonaws.com"
+          }
+        }
+      },
+      {
+        # Standalone RDS (non-Aurora) instance creates. Discriminated from
+        # RdsCreateAuroraClusterInstance by rds:ManageMasterUserPassword = true,
+        # which is absent on Aurora cluster member creates (password is managed
+        # at the cluster level). Engine pinned to postgres; storage encryption
+        # and public access enforced at create time.
+        Sid    = "RdsCreateDbInstance"
+        Effect = "Allow"
+        Action = "rds:CreateDBInstance"
+        Resource = [
+          local.rds_resources.db,
+          local.rds_resources.subgrp,
+          local.rds_resources.pg_all,
+        ]
+        Condition = {
+          Bool = {
+            "rds:ManageMasterUserPassword" = "true"
+            "rds:PubliclyAccessible"       = "false"
+            "rds:StorageEncrypted"         = "true"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "rds:DatabaseEngine"       = "postgres"
+          }
+        }
+      },
+      {
+        Sid    = "RdsCreateAuroraCluster"
+        Effect = "Allow"
+        Action = "rds:CreateDBCluster"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg_all,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          Bool = {
+            "rds:ManageMasterUserPassword" = "true"
+            "rds:StorageEncrypted"         = "true"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "rds:DatabaseEngine"       = "aurora-postgresql"
+          }
+        }
+      },
+      {
+        Sid    = "RdsCreateAuroraClusterInstance"
+        Effect = "Allow"
+        Action = "rds:CreateDBInstance"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.db,
+          local.rds_resources.pg_all,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          Bool = {
+            "rds:PubliclyAccessible" = "false"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "rds:DatabaseEngine"       = "aurora-postgresql"
+          }
+        }
+      },
+      {
+        Sid    = "RdsCreateParameterGroups"
+        Effect = "Allow"
+        Action = [
+          "rds:CreateDBClusterParameterGroup",
+          "rds:CreateDBParameterGroup",
+        ]
+        Resource = [
+          local.rds_resources.cluster_pg,
+          local.rds_resources.pg_sb,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateDbSubnetGroup"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBSubnetGroup"
+        Resource = local.rds_resources.subgrp
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsTagOnCreate"
+        Effect = "Allow"
+        Action = "rds:AddTagsToResource"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsTagNativeSnapshotOnCreate"
+        Effect = "Allow"
+        Action = "rds:AddTagsToResource"
+        Resource = [
+          local.rds_resources.cluster_snapshot,
+          local.rds_resources.snapshot,
+        ]
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsEncryptedStorageKmsViaRds"
+        Effect = "Allow"
+        Action = [
+          "kms:CreateGrant",
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey",
+        ]
+        Resource = "*"
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_provisioning" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_rds_provisioning[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: RDS mutation — modify, delete, snapshots, tag management
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-rds-mutation-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to modify, delete, snapshot, and tag RDS/Aurora resources it owns."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RdsMutate"
+        Effect = "Allow"
+        Action = [
+          "rds:DeleteDBCluster",
+          "rds:DeleteDBClusterParameterGroup",
+          "rds:DeleteDBInstance",
+          "rds:DeleteDBParameterGroup",
+          "rds:DeleteDBSubnetGroup",
+          "rds:ModifyDBCluster",
+          "rds:ModifyDBClusterParameterGroup",
+          "rds:ModifyDBInstance",
+          "rds:ModifyDBParameterGroup",
+          "rds:ModifyDBSubnetGroup",
+          "rds:RebootDBCluster",
+          "rds:RebootDBInstance",
+          "rds:ResetDBClusterParameterGroup",
+          "rds:ResetDBParameterGroup",
+        ]
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.pg_all,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          BoolIfExists = {
+            "rds:ManageMasterUserPassword" = "true"
+          }
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsDeleteAuroraClusterFinalSnapshot"
+        Effect   = "Allow"
+        Action   = "rds:DeleteDBCluster"
+        Resource = local.rds_resources.cluster_snapshot
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateSnapshotFromManagedCluster"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBClusterSnapshot"
+        Resource = local.rds_resources.cluster
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateNativeClusterSnapshot"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBClusterSnapshot"
+        Resource = local.rds_resources.cluster_snapshot
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateSnapshotFromManagedInstance"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBSnapshot"
+        Resource = local.rds_resources.db
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateNativeSnapshot"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBSnapshot"
+        Resource = local.rds_resources.snapshot
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsAddTagsToManagedResources"
+        Effect = "Allow"
+        Action = "rds:AddTagsToResource"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.cluster_snapshot,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.pg_all,
+          local.rds_resources.snapshot,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsRemoveTagsExceptScopingTags"
+        Effect = "Allow"
+        Action = "rds:RemoveTagsFromResource"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.cluster_snapshot,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.pg_all,
+          local.rds_resources.snapshot,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+          "ForAllValues:StringNotEquals" = {
+            "aws:TagKeys" = ["ManagedBy", "Vpc"]
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_mutation" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_rds_mutation[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: EC2 networking — VPC describe + security group management
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-ec2-provisioning-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to describe VPCs and manage security groups it created."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Sid    = "Ec2VpcDescribe"
+          Effect = "Allow"
+          Action = [
+            "ec2:DescribeAccountAttributes",
+            "ec2:DescribeAvailabilityZones",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribeSecurityGroupRules",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeTags",
+            "ec2:DescribeVpcAttribute",
+            "ec2:DescribeVpcs",
+          ]
+          Resource = "*"
+        },
+        {
+          Sid      = "Ec2CreateSecurityGroupResource"
+          Effect   = "Allow"
+          Action   = ["ec2:CreateSecurityGroup"]
+          Resource = "${local.ec2_prefix}:security-group/*"
+          Condition = {
+            StringEquals = {
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+            }
+          }
+        },
+        {
+          Sid    = "Ec2SecurityGroupMutate"
+          Effect = "Allow"
+          Action = [
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:DeleteSecurityGroup",
+            "ec2:ModifySecurityGroupRules",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:RevokeSecurityGroupIngress",
+          ]
+          Resource = "*"
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+          }
+        },
+        {
+          Sid    = "Ec2CreateTagsOnCreateSecurityGroup"
+          Effect = "Allow"
+          Action = ["ec2:CreateTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+              "ec2:CreateAction"         = "CreateSecurityGroup"
+            }
+          }
+        },
+        {
+          Sid    = "Ec2CreateTagsOnManagedResources"
+          Effect = "Allow"
+          Action = ["ec2:CreateTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+            StringEqualsIfExists = {
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+            }
+          }
+        },
+        {
+          Sid    = "Ec2DeleteTagsExceptScopingTags"
+          Effect = "Allow"
+          Action = ["ec2:DeleteTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+            "ForAllValues:StringNotEquals" = {
+              "aws:TagKeys" = ["ManagedBy", "Vpc"]
+            }
+          }
+        },
+      ],
+      local.agent_ec2_create_sg_vpc_statements[each.key]
+    )
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_ec2_provisioning" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_ec2_provisioning[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: Secrets Manager
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_secrets" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-secrets-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to manage RDS master credentials and read RDS-managed secrets."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CreateRdsManagedMasterSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:CreateSecret"
+        Resource = [
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+        ]
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "TagRdsManagedMasterSecretsViaRds"
+        Effect = "Allow"
+        Action = "secretsmanager:TagResource"
+        Resource = [
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+        ]
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "DescribeRdsManagedSecretKmsKeyViaRds"
+        Effect   = "Allow"
+        Action   = "kms:DescribeKey"
+        Resource = "*"
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "ReadTaggedRdsManagedMasterSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecretValue",
+        ]
+        Resource = [
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      local.agent_rds_secret_kms_statements[each.key],
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_secrets" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_secrets[each.key].arn
+}
+
+####################################################################
+# Connector IAM Role (one per agent)
+#
+# Assumed at query time by the OPA serving code to generate an RDS IAM
+# authentication token. Trusts only that agent's lifecycle worker role(s).
+#
+# Policy contains one rds-db:connect statement per profile, scoping
+# access to DB users in the sbndb_{profile}_*_runtime namespace.
+#
+# Role name format: superblocks-native-db-connector-{agent_name}
+# "superblocks-native-db-connector" is a reserved prefix: the Superblocks
+# server rejects customer-provided role names starting with it.
+####################################################################
+resource "aws_iam_role" "connector" {
+  for_each = var.agents
+
+  name = "superblocks-native-db-connector-${each.key}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowOnlyTrustedOpa"
+        Effect    = "Allow"
+        Action    = "sts:AssumeRole"
+        Principal = { AWS = [local.agent_role_arns[each.key]] }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "connector" {
+  for_each = var.agents
+
+  name        = "superblocks-native-db-connector-${each.key}"
+  description = "Allows the ${each.key} connector role to authenticate to RDS/Aurora instances using IAM database authentication."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      for tag in each.value.agent_tags : {
+        Sid    = "ConnectTag${replace(replace(title(tag), "-", ""), "_", "")}"
+        Effect = "Allow"
+        Action = "rds-db:connect"
+        Resource = [
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:cluster-*/sbndb_${tag}_*_runtime",
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:db-*/sbndb_${tag}_*_runtime",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "connector" {
+  for_each   = var.agents
+  role       = aws_iam_role.connector[each.key].name
+  policy_arn = aws_iam_policy.connector[each.key].arn
+}
+
+####################################################################
+# S3 OpenTofu State Bucket
+#
+# Shared across all agents in this module invocation (same account+region).
+# Always created — no conditional logic needed since all agents are declared
+# in this single module call.
+#
+# Bucket name format: <name_prefix>-<region>-<account_id>
+####################################################################
+resource "aws_s3_bucket" "tofu_state" {
+  bucket = "${var.name_prefix}-${var.region}-${data.aws_caller_identity.current.account_id}"
+
+  tags = local.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tofu_state" {
+  bucket = aws_s3_bucket.tofu_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tofu_state" {
+  bucket = aws_s3_bucket.tofu_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tofu_state" {
+  count  = var.kms_key_arn != null ? 1 : 0
+  bucket = aws_s3_bucket.tofu_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = false
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tofu_state" {
+  bucket = aws_s3_bucket.tofu_state.id
+
+  rule {
+    id     = "expire-noncurrent-state-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -3,12 +3,18 @@ output "agents" {
     for k in keys(var.agents) : k => {
       lifecycle_worker_role_arn = local.agent_role_arns[k]
       connector_role_arn        = aws_iam_role.connector[k].arn
+      agent_tags                = var.agents[k].agent_tags
     }
   }
-  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role — set as the ECS task role or annotate the EKS service account) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role), connector_role_arn (pass as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN), and agent_tags (pass as agent_tags to the native-db module)."
 }
 
 output "state_bucket_name" {
   value       = aws_s3_bucket.tofu_state.id
   description = "Name of the S3 bucket used for OpenTofu state, shared across all agents in this module invocation."
+}
+
+output "tags" {
+  value       = var.tags
+  description = "Tags applied to all resources created by this module. Pass to the native-db module's physical_module_inputs.tags to tag RDS instances with the same values."
 }

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -1,0 +1,14 @@
+output "agents" {
+  value = {
+    for k in keys(var.agents) : k => {
+      lifecycle_worker_role_arn = local.agent_role_arns[k]
+      connector_role_arn        = aws_iam_role.connector[k].arn
+    }
+  }
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role — set as the ECS task role or annotate the EKS service account) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "state_bucket_name" {
+  value       = aws_s3_bucket.tofu_state.id
+  description = "Name of the S3 bucket used for OpenTofu state, shared across all agents in this module invocation."
+}

--- a/modules/native-db-prereqs/provider.tf
+++ b/modules/native-db-prereqs/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -1,0 +1,80 @@
+variable "deployment_type" {
+  type        = string
+  description = "Deployment type: 'eks' or 'fargate'. Applies to all agents in this module invocation."
+
+  validation {
+    condition     = contains(["eks", "fargate"], var.deployment_type)
+    error_message = "Variable `deployment_type` must be 'eks' or 'fargate'."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region where resources are created."
+
+  validation {
+    condition     = length(var.region) > 0
+    error_message = "Variable `region` cannot be empty."
+  }
+}
+
+variable "agents" {
+  type = map(object({
+    agent_tags             = list(string)
+    vpc_id                 = string
+    oidc_provider_arn      = optional(string)
+    namespace              = optional(string, "superblocks")
+    service_account_name   = optional(string, "superblocks-agent")
+    existing_role_name     = optional(string)
+    rds_secret_kms_key_arn = optional(string)
+  }))
+  description = "Map of OPA agent configurations keyed by agent name. The map key is the agent name — used to name IAM roles and must be unique per AWS account. Each agent gets its own lifecycle worker role (or attaches to an existing one via existing_role_name) and connector role; all agents share one S3 state bucket per module invocation."
+
+  validation {
+    condition     = length(var.agents) > 0
+    error_message = "At least one agent must be provided."
+  }
+
+  validation {
+    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9-]{1,15}$", k))])
+    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters or hyphens."
+  }
+
+  validation {
+    condition = alltrue([
+      for agent in values(var.agents) :
+      length(agent.agent_tags) > 0 &&
+      alltrue([for t in agent.agent_tags : can(regex("^[a-z0-9-]{1,15}$", t))]) &&
+      length(agent.agent_tags) == length(toset(agent.agent_tags))
+    ])
+    error_message = "Each agent must have at least one unique agent_tag; tag names must be 1-15 lowercase alphanumeric characters or hyphens."
+  }
+
+  validation {
+    condition     = alltrue([for agent in values(var.agents) : can(regex("^vpc-[0-9a-f]+$", agent.vpc_id))])
+    error_message = "Each agent's vpc_id must be a valid VPC ID (e.g. vpc-0123456789abcdef0)."
+  }
+}
+
+variable "name_prefix" {
+  type        = string
+  default     = "sb-native-db"
+  description = "Prefix applied to all IAM roles, policies, and the S3 state bucket created by this module. Defaults to 'sb-native-db'. Override when your organization requires a specific naming convention. Max 16 characters (combined with region (≤14) and account ID (12) the bucket name stays under S3's 63-character limit)."
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{0,14}[a-z0-9]$", var.name_prefix))
+    error_message = "Variable name_prefix must be 2-16 lowercase alphanumeric characters or hyphens, and must not start or end with a hyphen."
+  }
+}
+
+variable "kms_key_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the KMS key for the OpenTofu state bucket. When provided, the bucket is configured with SSE-KMS using this key and IAM KMS permissions are scoped to it. When null, the bucket uses the AWS account default encryption and IAM KMS permissions fall back to Resource:* conditioned on aws:CalledVia s3.amazonaws.com."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags to apply to all resources created by this module. Do not set ManagedBy — the module always enforces ManagedBy = \"superblocks-native-database-lifecycle\", which is required for IAM conditions that scope the lifecycle worker's blast radius."
+}

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -36,8 +36,8 @@ variable "agents" {
   }
 
   validation {
-    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9-]{1,15}$", k))])
-    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters or hyphens."
+    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9_-]{1,15}$", k))])
+    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters, hyphens, or underscores."
   }
 
   validation {

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -148,6 +148,10 @@ locals {
       value = "${local.logical_module_source},${local.physical_module_source}"
     },
     {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_AGENT_NAME"
+      value = var.agent_name
+    },
+    {
       name  = "SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN"
       value = var.connector_role_arn
     },

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -1,0 +1,175 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Module sources relative to the dispatch working directory. The Superblocks
+  # OPA image vendors these modules at a fixed path — customers do not configure
+  # them.
+  logical_module_source  = "./modules/postgres-managed-database"
+  physical_module_source = "./modules/aws-rds-managed-instance"
+
+  # SSL cert path baked into the Superblocks OPA image.
+  ssl_root_cert = "/etc/ssl/certs/aws-rds-global-bundle.pem"
+
+  # S3 backend base config shared by all operations. The per-operation `key`
+  # is set via merge() below so that logical and physical state land under
+  # separate prefixes in the same bucket.
+  s3_backend_base = {
+    stateBackend = "s3"
+    bucket       = var.state_bucket_name
+    region       = var.region
+    use_lockfile = true
+  }
+
+  # Physical module inputs forwarded to ensure_physical_database_instance.
+  # publicly_accessible is always false — the lifecycle worker IAM policy
+  # enforces this at create time regardless of module input.
+  physical_inputs = {
+    allocated_storage         = var.physical_module_inputs.allocated_storage
+    allowed_cidr_blocks       = var.physical_module_inputs.allowed_cidr_blocks
+    backup_retention_period   = var.physical_module_inputs.backup_retention_period
+    delete_automated_backups  = var.physical_module_inputs.delete_automated_backups
+    deletion_protection       = var.physical_module_inputs.deletion_protection
+    instance_class            = var.physical_module_inputs.instance_class
+    multi_az                  = var.physical_module_inputs.multi_az
+    publicly_accessible       = false
+    skip_final_snapshot       = var.physical_module_inputs.skip_final_snapshot
+    source_security_group_ids = var.physical_module_inputs.source_security_group_ids
+    subnet_ids                = var.physical_module_inputs.subnet_ids
+    tags                      = var.physical_module_inputs.tags
+    vpc_id                    = var.physical_module_inputs.vpc_id
+  }
+
+  # Logical module inputs shared by ensure_database and retire_database.
+  logical_inputs = {
+    auth_mode          = "aws_iam_role"
+    connector_role_arn = var.connector_role_arn
+    postgres_sslmode   = "verify-full"
+    postgres_sslrootcert = local.ssl_root_cert
+  }
+
+  # Terraform config shared by ensure_database and retire_database (same
+  # logical backend key and module).
+  logical_terraform = {
+    backend = merge(local.s3_backend_base, {
+      key = "${var.key_prefix}/logical/{{environment}}/{{profile}}/{{resource_key}}.tfstate"
+    })
+    credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
+    moduleSelectors = {
+      postgres = {
+        source = local.logical_module_source
+        inputs = local.logical_inputs
+      }
+    }
+  }
+
+  lifecycle_operations = {
+    ensure_database = {
+      backend = "terraform"
+      physicalDatabase = {
+        mode               = "shared_pool"
+        provisionOperation = "ensure_physical_database_instance"
+        onExhausted        = "provision"
+        capacityMax        = var.pool.max_databases
+        securityClass      = "standard"
+      }
+      terraform = local.logical_terraform
+    }
+
+    ensure_physical_database_instance = {
+      backend = "terraform"
+      terraform = {
+        backend = merge(local.s3_backend_base, {
+          key = "${var.key_prefix}/physical/{{environment}}/{{profile}}/{{resource_key}}.tfstate"
+        })
+        credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
+        moduleSelectors = {
+          postgres = {
+            source = local.physical_module_source
+            inputs = local.physical_inputs
+          }
+        }
+      }
+    }
+
+    # Schema migrations run natively inside the OPA process — no Terraform.
+    migrate_schema = { backend = "native_runner" }
+
+    # retire_database reuses the logical Terraform root so tofu destroy targets
+    # the same state as ensure_database.
+    retire_database = {
+      backend   = "terraform"
+      terraform = local.logical_terraform
+    }
+  }
+
+  # One entry covers all profiles this OPA serves. Profiles must be explicit
+  # (no wildcard) and must match the agent_tags declared in native-db-prereqs.
+  lifecycle_config = {
+    entries = [
+      {
+        profiles   = var.agent_tags
+        engines    = ["postgres"]
+        operations = local.lifecycle_operations
+      }
+    ]
+  }
+
+  # Scope the secrets refresolver to only RDS-managed master secrets in this
+  # account and region. The lifecycle worker reads these to connect as the
+  # admin user when provisioning logical databases.
+  allowed_ref_prefixes = [
+    "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-",
+    "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-",
+  ]
+
+  ecs_env_vars = [
+    {
+      name  = "SUPERBLOCKS_ORCHESTRATOR_DATABASE_LIFECYCLE_WORKER_ENABLED"
+      value = "true"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ROOT_DIR"
+      value = "/var/lib/superblocks/database-lifecycle"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_TERRAFORM_BIN"
+      value = "/usr/local/bin/tofu"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_POLL_INTERVAL"
+      value = "5s"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES"
+      value = "aws_db_instance,aws_db_subnet_group,aws_secretsmanager_secret,aws_secretsmanager_secret_version,aws_security_group,aws_security_group_rule,postgresql_database,postgresql_default_privileges,postgresql_grant,postgresql_role,postgresql_schema,random_id,terraform_data"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
+      value = "${local.logical_module_source},${local.physical_module_source}"
+    },
+    {
+      name  = "SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN"
+      value = var.connector_role_arn
+    },
+    {
+      name  = "SUPERBLOCKS_POSTGRES_IAM_ALLOWED_ROLE_ARN_PREFIXES"
+      value = jsonencode([var.connector_role_arn])
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_SSL_MODE"
+      value = "verify-full"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_SSL_ROOT_CERT"
+      value = local.ssl_root_cert
+    },
+    {
+      name  = "SUPERBLOCKS_SECRETS_REFRESOLVER_ALLOWED_REF_PREFIXES"
+      value = join(",", local.allowed_ref_prefixes)
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+      value = jsonencode(local.lifecycle_config)
+    },
+  ]
+}

--- a/modules/native-db/outputs.tf
+++ b/modules/native-db/outputs.tf
@@ -1,0 +1,4 @@
+output "ecs_env_vars" {
+  value       = local.ecs_env_vars
+  description = "Environment variables for the Superblocks Agent ECS container. Pass as superblocks_agent_environment_variables in the terraform_aws_superblocks root module."
+}

--- a/modules/native-db/provider.tf
+++ b/modules/native-db/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -1,0 +1,90 @@
+variable "connector_role_arn" {
+  type        = string
+  description = "ARN of the connector IAM role (from the native-db-prereqs module output agents[<name>].connector_role_arn). Used to authenticate against RDS via IAM at query time."
+}
+
+variable "state_bucket_name" {
+  type        = string
+  description = "Name of the shared S3 state bucket (from the native-db-prereqs module output state_bucket_name). Shared across all OPAs in the same region."
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region where the S3 state bucket and RDS instances live."
+
+  validation {
+    condition     = length(var.region) > 0
+    error_message = "region cannot be empty."
+  }
+}
+
+variable "key_prefix" {
+  type        = string
+  description = "Prefix that namespaces this OPA's OpenTofu state within the shared S3 bucket. Must be unique per OPA — using the agent name as a suffix is recommended (e.g. \"native-db/prod\"). Logical database state lands under <key_prefix>/logical/... and physical instance state under <key_prefix>/physical/..."
+
+  validation {
+    condition     = length(var.key_prefix) > 0 && !startswith(var.key_prefix, "/") && !endswith(var.key_prefix, "/")
+    error_message = "key_prefix must be non-empty and must not start or end with a slash."
+  }
+}
+
+variable "agent_tags" {
+  type        = list(string)
+  description = "Agent profile tags this OPA is registered with (from the native-db-prereqs module output agents[<name>].agent_tags). Used to populate the lifecycle config profiles — must match the agent_tags the OPA advertises to Superblocks. Wildcards are not permitted."
+
+  validation {
+    condition     = length(var.agent_tags) > 0
+    error_message = "agent_tags must contain at least one profile tag."
+  }
+
+  validation {
+    condition     = !contains(var.agent_tags, "*")
+    error_message = "Wildcard '*' is not permitted in agent_tags. Use explicit profile keys."
+  }
+}
+
+variable "pool" {
+  type = object({
+    max_databases = optional(number, 100)
+  })
+  default     = {}
+  description = "Shared physical pool configuration. max_databases sets the maximum number of logical databases a single RDS instance can hold before a new instance is automatically provisioned. Defaults to 100."
+
+  validation {
+    condition     = var.pool.max_databases > 0
+    error_message = "pool.max_databases must be a positive integer."
+  }
+}
+
+variable "physical_module_inputs" {
+  type = object({
+    allocated_storage         = number
+    allowed_cidr_blocks       = optional(list(string), [])
+    backup_retention_period   = optional(number, 7)
+    delete_automated_backups  = optional(bool, true)
+    deletion_protection       = optional(bool, true)
+    instance_class            = string
+    multi_az                  = optional(bool, true)
+    skip_final_snapshot       = optional(bool, false)
+    source_security_group_ids = optional(list(string), [])
+    subnet_ids                = list(string)
+    tags                      = optional(map(string), {})
+    vpc_id                    = string
+  })
+  description = "Physical database configuration applied to every RDS instance this OPA provisions. publicly_accessible is always false and is not configurable — it is enforced by the lifecycle worker IAM policy regardless."
+
+  validation {
+    condition     = var.physical_module_inputs.allocated_storage > 0
+    error_message = "physical_module_inputs.allocated_storage must be a positive integer."
+  }
+
+  validation {
+    condition     = length(var.physical_module_inputs.subnet_ids) >= 2
+    error_message = "physical_module_inputs.subnet_ids must contain at least two subnet IDs (the DB subnet group requires subnets in at least two Availability Zones)."
+  }
+
+  validation {
+    condition     = can(regex("^vpc-[0-9a-f]+$", var.physical_module_inputs.vpc_id))
+    error_message = "physical_module_inputs.vpc_id must be a valid VPC ID (e.g. vpc-0123456789abcdef0)."
+  }
+}

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -28,6 +28,16 @@ variable "key_prefix" {
   }
 }
 
+variable "agent_name" {
+  type        = string
+  description = "Stable name for this OPA deployment (the agents map key from native-db-prereqs, e.g. \"opa1\"). Used as the physical database pool identity. Must be unique within your AWS account and must not change once databases exist."
+
+  validation {
+    condition     = can(regex("^[a-z0-9_-]{1,15}$", var.agent_name))
+    error_message = "agent_name must be 1–15 lowercase alphanumeric characters, hyphens, or underscores (matching the agents map key constraint in native-db-prereqs)."
+  }
+}
+
 variable "agent_tags" {
   type        = list(string)
   description = "Agent profile tags this OPA is registered with (from the native-db-prereqs module output agents[<name>].agent_tags). Used to populate the lifecycle config profiles — must match the agent_tags the OPA advertises to Superblocks. Wildcards are not permitted."


### PR DESCRIPTION
## Summary

- Adds `modules/native-db`, which generates the full set of OPA environment variables (`ecs_env_vars`) for Fargate/ECS deployments
- Lifecycle config uses the post-PR-2850 flat structure: explicit profiles from `agent_tags`, no `environment` field, no wildcard profiles
- Extends `modules/native-db-prereqs` outputs with `agent_tags` and `tags` so they wire directly into `native-db` without duplication
- Updates `examples/native-db-fargate` with step 2 showing the full two-module setup

## Key design decisions

- `ecs_env_vars` is `list(map(string))` — compatible with `superblocks_agent_environment_variables` in the root module (ENG-4960)
- All internal config (SSL paths, allowed resource types, ref prefix patterns) is hardcoded — not exposed to customers
- `physical_module_inputs`: `instance_class`, `allocated_storage`, `vpc_id`, `subnet_ids` are required; everything else has sensible defaults
- `pool.max_databases` defaults to 100 (matches orchestrator default)

## Test plan

- [ ] `terraform validate` passes in `examples/native-db-fargate`
- [ ] `terraform validate` passes in `examples/native-db-eks`
- [ ] `ecs_env_vars` output shape is `[{name = "...", value = "..."}]`
- [ ] `SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG` JSON has no `environment` field and no wildcard profiles

Closes ENG-4959