### PR TITLE
feat(native-db-prereqs): grant lifecycle workers observability IAM

### DIFF
--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -66,11 +66,28 @@ module "native_db_prereqs" {
   # Optional: customer-managed KMS key for the OpenTofu state bucket.
   # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
 
+  # Optional: reuse an account-level Enhanced Monitoring role created by a
+  # prior regional apply of this module. The role name is account-scoped
+  # (superblocks-native-db-monitoring), so a second region must pass the ARN
+  # from the first instead of creating another copy.
+  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/superblocks-native-db-monitoring"
+
   # Optional: additional tags applied to all resources created by this module.
   tags = {
     Environment = "production"
   }
 }
+
+# Wire enhanced_monitoring_role_arn into the OPA Helm chart so physical
+# modules can attach Enhanced Monitoring (default monitoring_interval is 60).
+# Without this, plans fail the module precondition even though the IAM role
+# exists:
+#
+#   databaseLifecycle:
+#     physicalModuleInputs:
+#       monitoring_role_arn: <module.native_db_prereqs.enhanced_monitoring_role_arn>
+#
+# Or opt out with monitoring_interval: 0.
 
 output "agents" {
   value       = module.native_db_prereqs.agents

--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -68,9 +68,9 @@ module "native_db_prereqs" {
 
   # Optional: reuse an account-level Enhanced Monitoring role created by a
   # prior regional apply of this module. The role name is account-scoped
-  # (superblocks-native-db-monitoring), so a second region must pass the ARN
+  # (<name_prefix>-enhanced-monitoring), so a second region must pass the ARN
   # from the first instead of creating another copy.
-  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/superblocks-native-db-monitoring"
+  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
 
   # Optional: additional tags applied to all resources created by this module.
   tags = {

--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -77,6 +77,11 @@ output "agents" {
   description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (annotate the OPA service account via eks.amazonaws.com/role-arn) and connector_role_arn (pass to OPA Helm chart as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
 }
 
+output "enhanced_monitoring_role_arn" {
+  value       = module.native_db_prereqs.enhanced_monitoring_role_arn
+  description = "Pass to OPA Helm as databaseLifecycle.physicalModuleInputs.monitoring_role_arn so Enhanced Monitoring can attach. Required unless you set monitoring_interval: 0."
+}
+
 output "state_bucket_name" {
   value       = module.native_db_prereqs.state_bucket_name
   description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -56,11 +56,22 @@ module "native_db_prereqs" {
   # When omitted, the bucket uses AWS account-default encryption (SSE-S3).
   # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
 
+  # Optional: reuse an account-level Enhanced Monitoring role created by a
+  # prior regional apply of this module. The role name is account-scoped
+  # (superblocks-native-db-monitoring), so a second region must pass the ARN
+  # from the first instead of creating another copy.
+  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/superblocks-native-db-monitoring"
+
   # Optional: additional tags applied to all resources created by this module.
   tags = {
     Environment = "production"
   }
 }
+
+# Pass enhanced_monitoring_role_arn into modules/native-db (step 2) as
+# physical_module_inputs.monitoring_role_arn. Physical modules default
+# monitoring_interval to 60 and reject plans when the role ARN is missing.
+# Opt out with monitoring_interval = 0.
 
 output "agents" {
   value       = module.native_db_prereqs.agents

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -67,6 +67,11 @@ output "agents" {
   description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (set as ECS task role ARN) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
 }
 
+output "enhanced_monitoring_role_arn" {
+  value       = module.native_db_prereqs.enhanced_monitoring_role_arn
+  description = "Pass into modules/native-db (or physicalModuleInputs.monitoring_role_arn) so Enhanced Monitoring can attach. Required unless you set monitoring_interval = 0."
+}
+
 output "state_bucket_name" {
   value       = module.native_db_prereqs.state_bucket_name
   description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -58,9 +58,9 @@ module "native_db_prereqs" {
 
   # Optional: reuse an account-level Enhanced Monitoring role created by a
   # prior regional apply of this module. The role name is account-scoped
-  # (superblocks-native-db-monitoring), so a second region must pass the ARN
+  # (<name_prefix>-enhanced-monitoring), so a second region must pass the ARN
   # from the first instead of creating another copy.
-  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/superblocks-native-db-monitoring"
+  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
 
   # Optional: additional tags applied to all resources created by this module.
   tags = {

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -920,6 +920,11 @@ resource "aws_iam_policy" "lifecycle_worker_observability" {
         Action   = "logs:DescribeLogGroups"
         Resource = "*"
       },
+      # CreateDBInstance passes the monitoring role as rds.amazonaws.com, not as
+      # the monitoring.rds.amazonaws.com principal that assumes it. Conditioning
+      # on the latter denies every physical provision once monitoring_interval
+      # is non-zero: AWS reports "no identity-based policy allows the
+      # iam:PassRole action" even though the statement's resource matches.
       {
         Sid      = "PassEnhancedMonitoringRole"
         Effect   = "Allow"
@@ -927,7 +932,7 @@ resource "aws_iam_policy" "lifecycle_worker_observability" {
         Resource = local.monitoring_role_arn
         Condition = {
           StringEquals = {
-            "iam:PassedToService" = "monitoring.rds.amazonaws.com"
+            "iam:PassedToService" = "rds.amazonaws.com"
           }
         }
       },

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -950,11 +950,16 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_observability" {
 # role is reused by all of them and the worker never needs iam:CreateRole.
 # The ArnLike/SourceAccount pair is confused-deputy protection — without it
 # any RDS database in any account could name this role.
+#
+# IAM role names are account-global, so this name cannot repeat within one
+# account: a second region (or a second install) must pass
+# existing_monitoring_role_arn instead of letting the module create its own,
+# or CreateRole fails with EntityAlreadyExists.
 ####################################################################
 resource "aws_iam_role" "enhanced_monitoring" {
   count = local.create_monitoring_role ? 1 : 0
 
-  name = "superblocks-native-db-monitoring"
+  name = "${var.name_prefix}-enhanced-monitoring"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -50,6 +50,31 @@ locals {
     subgrp           = "${local.rds_prefix}:subgrp:sb-*"
   }
 
+  # Log groups the physical modules declare explicitly, named
+  # /aws/rds/{cluster,instance}/<sb-identifier>/<log type>.
+  native_cloudwatch_log_group_arn_patterns = [
+    "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/cluster/sb-*",
+    "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/instance/sb-*",
+  ]
+
+  # Regions are wildcarded because one account-level monitoring role serves
+  # every region the worker provisions into; aws:SourceAccount is what blocks
+  # cross-account use.
+  native_rds_monitoring_source_arn_patterns = [
+    "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:cluster:sb-*",
+    "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:db:sb-*",
+  ]
+
+  # Account-level Enhanced Monitoring role. The physical modules never create
+  # it — callers pass this ARN as monitoring_role_arn. Additional regions can
+  # reuse an existing role via existing_monitoring_role_arn.
+  create_monitoring_role = var.existing_monitoring_role_arn == null
+  monitoring_role_arn = (
+    local.create_monitoring_role
+    ? aws_iam_role.enhanced_monitoring[0].arn
+    : var.existing_monitoring_role_arn
+  )
+
   # ----------------------------------------------------------------
   # S3 state bucket ARN (always created, shared across all agents)
   # ----------------------------------------------------------------
@@ -852,6 +877,118 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_secrets" {
   for_each   = var.agents
   role       = local.agent_role_names[each.key]
   policy_arn = aws_iam_policy.lifecycle_worker_secrets[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: Observability (CloudWatch log groups + Enhanced Monitoring PassRole)
+#
+# The physical modules declare CloudWatch log groups explicitly so retention
+# is managed rather than left unbounded, and they attach the shared
+# monitoring role below. AWS requires whoever enables Enhanced Monitoring to
+# hold iam:PassRole on the role being handed to RDS, so that grant is scoped
+# to the single role and conditioned on the one service allowed to receive it.
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_observability" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-observability-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to manage Native DB CloudWatch log groups and pass the shared Enhanced Monitoring role."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CloudWatchLogGroupsForNativeDatabases"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DeleteLogGroup",
+          "logs:ListTagsForResource",
+          "logs:PutRetentionPolicy",
+          "logs:TagResource",
+          "logs:UntagResource",
+        ]
+        Resource = local.native_cloudwatch_log_group_arn_patterns
+      },
+      # The provider reads aws_cloudwatch_log_group through DescribeLogGroups,
+      # which AWS authorizes only against "*" — an iam:SimulateCustomPolicy run
+      # denies it against every log-group ARN pattern. Listing it beside the
+      # scoped actions above silently loses the permission at refresh time.
+      {
+        Sid      = "DescribeLogGroupsIsNotResourceScopable"
+        Effect   = "Allow"
+        Action   = "logs:DescribeLogGroups"
+        Resource = "*"
+      },
+      {
+        Sid      = "PassEnhancedMonitoringRole"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = local.monitoring_role_arn
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "monitoring.rds.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_observability" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_observability[each.key].arn
+}
+
+####################################################################
+# Enhanced Monitoring IAM Role (one per account, shared by all agents)
+#
+# RDS assumes this role to publish Enhanced Monitoring OS metrics to the
+# RDSOSMetrics log group. The physical modules never create it: the attached
+# AWS-managed policy is identical for every database, so one account-level
+# role is reused by all of them and the worker never needs iam:CreateRole.
+# The ArnLike/SourceAccount pair is confused-deputy protection — without it
+# any RDS database in any account could name this role.
+####################################################################
+resource "aws_iam_role" "enhanced_monitoring" {
+  count = local.create_monitoring_role ? 1 : 0
+
+  name = "superblocks-native-db-monitoring"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowRdsEnhancedMonitoringForLifecycleDatabases"
+        Effect = "Allow"
+        Principal = {
+          Service = "monitoring.rds.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = local.native_rds_monitoring_source_arn_patterns
+          }
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  description = "RDS Enhanced Monitoring role shared by every native-database instance and cluster"
+
+  tags = merge(local.tags, {
+    Purpose = "RDS Enhanced Monitoring for native databases"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
+  count = local.create_monitoring_role ? 1 : 0
+
+  role       = aws_iam_role.enhanced_monitoring[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
 ####################################################################

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -8,6 +8,11 @@ output "agents" {
   description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role — set as the ECS task role or annotate the EKS service account) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
 }
 
+output "enhanced_monitoring_role_arn" {
+  value       = local.monitoring_role_arn
+  description = "ARN of the account-level RDS Enhanced Monitoring role. Pass this to the physical database modules as monitoring_role_arn (for example via databaseLifecycle.physicalModuleInputs); without it they reject monitoring_interval > 0 at plan time."
+}
+
 output "state_bucket_name" {
   value       = aws_s3_bucket.tofu_state.id
   description = "Name of the S3 bucket used for OpenTofu state, shared across all agents in this module invocation."

--- a/modules/native-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/native-db-prereqs/tests/observability.tftest.hcl
@@ -1,0 +1,178 @@
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:root"
+      user_id    = "AIDAEXAMPLE"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock-role"
+      id  = "mock-role"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock-policy"
+      id  = "arn:aws:iam::123456789012:policy/mock-policy"
+    }
+  }
+
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      arn = "arn:aws:s3:::sb-native-db-us-east-1-123456789012"
+      id  = "sb-native-db-us-east-1-123456789012"
+    }
+  }
+}
+
+run "grants_native_database_observability_permissions" {
+  command = plan
+
+  variables {
+    deployment_type = "eks"
+    region          = "us-east-1"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for action in [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:ListTagsForResource",
+        "logs:PutRetentionPolicy",
+        "logs:TagResource",
+        "logs:UntagResource",
+      ] :
+      contains(one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "CloudWatchLogGroupsForNativeDatabases"
+      ]), action)
+    ])
+    error_message = "The worker must be able to manage the log groups the physical modules declare explicitly."
+  }
+
+  assert {
+    condition = jsonencode(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      statement.Resource if statement.Sid == "CloudWatchLogGroupsForNativeDatabases"
+      ])) == jsonencode([
+      "arn:aws:logs:us-east-1:123456789012:log-group:/aws/rds/cluster/sb-*",
+      "arn:aws:logs:us-east-1:123456789012:log-group:/aws/rds/instance/sb-*",
+    ])
+    error_message = "CloudWatch Logs grants must stay inside the sb-* namespace the physical modules generate."
+  }
+
+  # Verified with aws iam simulate-custom-policy: DescribeLogGroups evaluates to
+  # implicitDeny against a log-group ARN no matter how the pattern is written,
+  # and to allowed only against "*". Every other action here is resource
+  # scopable, so keeping them in one statement would silently widen them.
+  assert {
+    condition = !contains(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      statement.Action if statement.Sid == "CloudWatchLogGroupsForNativeDatabases"
+    ]), "logs:DescribeLogGroups")
+    error_message = "DescribeLogGroups cannot sit in the sb-* scoped statement: AWS will not authorize it against a log-group ARN, so the provider's read fails with AccessDenied."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "DescribeLogGroupsIsNotResourceScopable"
+      ]) == "logs:DescribeLogGroups" &&
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Resource if statement.Sid == "DescribeLogGroupsIsNotResourceScopable"
+      ]) == "*"
+    )
+    error_message = "The provider reads aws_cloudwatch_log_group through DescribeLogGroups, which only authorizes against \"*\"."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "PassEnhancedMonitoringRole"
+      ]) == "iam:PassRole" &&
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Resource if statement.Sid == "PassEnhancedMonitoringRole"
+      ]) == local.monitoring_role_arn &&
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Condition.StringEquals["iam:PassedToService"] if statement.Sid == "PassEnhancedMonitoringRole"
+      ]) == "monitoring.rds.amazonaws.com"
+    )
+    error_message = "Enhanced Monitoring attach requires iam:PassRole, scoped to the shared monitoring role and to RDS monitoring alone."
+  }
+
+  assert {
+    condition = (
+      aws_iam_role.enhanced_monitoring[0].name == "superblocks-native-db-monitoring" &&
+      jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Principal.Service == "monitoring.rds.amazonaws.com" &&
+      jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Action == "sts:AssumeRole" &&
+      jsonencode(jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Condition.ArnLike["aws:SourceArn"]) == jsonencode([
+        "arn:aws:rds:*:123456789012:cluster:sb-*",
+        "arn:aws:rds:*:123456789012:db:sb-*",
+      ]) &&
+      jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == "123456789012"
+    )
+    error_message = "The shared monitoring role must trust RDS monitoring for sb-* databases in this account only, across every region it provisions into."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.enhanced_monitoring[0].policy_arn == "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+    error_message = "The monitoring role must carry the AWS-managed Enhanced Monitoring policy rather than a hand-written copy."
+  }
+
+  assert {
+    condition     = output.enhanced_monitoring_role_arn == local.monitoring_role_arn
+    error_message = "The monitoring role ARN must be exported so operators can pass it as monitoring_role_arn to the physical modules."
+  }
+}
+
+run "reuses_an_existing_monitoring_role" {
+  command = plan
+
+  variables {
+    deployment_type              = "eks"
+    region                       = "us-west-2"
+    existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/platform/superblocks-native-db-monitoring"
+    agents = {
+      opa1 = {
+        agent_tags        = ["staging"]
+        vpc_id            = "vpc-0fedcba9876543210"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/EXAMPLE0987654321"
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_iam_role.enhanced_monitoring) == 0
+    error_message = "When existing_monitoring_role_arn is set, the module must not create a second monitoring role."
+  }
+
+  assert {
+    condition = one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      statement.Resource if statement.Sid == "PassEnhancedMonitoringRole"
+    ]) == "arn:aws:iam::123456789012:role/platform/superblocks-native-db-monitoring"
+    error_message = "A worker that reuses an existing monitoring role must be able to pass that role."
+  }
+
+  assert {
+    condition     = output.enhanced_monitoring_role_arn == "arn:aws:iam::123456789012:role/platform/superblocks-native-db-monitoring"
+    error_message = "The monitoring role output must expose the existing role when one is supplied."
+  }
+}

--- a/modules/native-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/native-db-prereqs/tests/observability.tftest.hcl
@@ -29,6 +29,65 @@ mock_provider "aws" {
   }
 }
 
+# The mock defaults above give every aws_iam_policy the same arn, which would
+# let a cross-resource assertion (attachment.policy_arn == policy.arn) pass
+# even if the attachment referenced an adjacent policy by mistake. Overriding
+# each address with its own arn makes those assertions load-bearing.
+override_resource {
+  target = aws_iam_role.lifecycle_worker
+  values = { arn = "arn:aws:iam::123456789012:role/mock-lifecycle-worker" }
+}
+
+override_resource {
+  target = aws_iam_role.connector
+  values = { arn = "arn:aws:iam::123456789012:role/mock-connector" }
+}
+
+override_resource {
+  target = aws_iam_role.enhanced_monitoring
+  values = { arn = "arn:aws:iam::123456789012:role/mock-enhanced-monitoring" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_observability
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-observability" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_secrets
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-secrets" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_assume_connector
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-assume-connector" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_state_bucket
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-state-bucket" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_rds_provisioning
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-rds-provisioning" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_rds_mutation
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-rds-mutation" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_ec2_provisioning
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-ec2-provisioning" }
+}
+
+override_resource {
+  target = aws_iam_policy.connector
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-connector-policy" }
+}
+
 run "grants_native_database_observability_permissions" {
   command = plan
 
@@ -119,7 +178,7 @@ run "grants_native_database_observability_permissions" {
 
   assert {
     condition = (
-      aws_iam_role.enhanced_monitoring[0].name == "superblocks-native-db-monitoring" &&
+      aws_iam_role.enhanced_monitoring[0].name == "sb-native-db-enhanced-monitoring" &&
       jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Principal.Service == "monitoring.rds.amazonaws.com" &&
       jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Action == "sts:AssumeRole" &&
       jsonencode(jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Condition.ArnLike["aws:SourceArn"]) == jsonencode([
@@ -156,7 +215,7 @@ run "reuses_an_existing_monitoring_role" {
   variables {
     deployment_type              = "eks"
     region                       = "us-west-2"
-    existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/platform/superblocks-native-db-monitoring"
+    existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/platform/sb-native-db-enhanced-monitoring"
     agents = {
       opa1 = {
         agent_tags        = ["staging"]
@@ -175,12 +234,55 @@ run "reuses_an_existing_monitoring_role" {
     condition = one([
       for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
       statement.Resource if statement.Sid == "PassEnhancedMonitoringRole"
-    ]) == "arn:aws:iam::123456789012:role/platform/superblocks-native-db-monitoring"
+    ]) == "arn:aws:iam::123456789012:role/platform/sb-native-db-enhanced-monitoring"
     error_message = "A worker that reuses an existing monitoring role must be able to pass that role."
   }
 
   assert {
-    condition     = output.enhanced_monitoring_role_arn == "arn:aws:iam::123456789012:role/platform/superblocks-native-db-monitoring"
+    condition     = output.enhanced_monitoring_role_arn == "arn:aws:iam::123456789012:role/platform/sb-native-db-enhanced-monitoring"
     error_message = "The monitoring role output must expose the existing role when one is supplied."
   }
+}
+
+# Every ARN this module builds hardcodes the aws partition, including the
+# AmazonRDSEnhancedMonitoringRole managed-policy ARN and the RDS SourceArn
+# patterns in the trust policy. A GovCloud role would pass an ARN-shape check
+# but never actually be assumable by monitoring.rds.amazonaws.com here, so the
+# validation has to reject it at plan time rather than at provision time.
+run "rejects_a_monitoring_role_outside_the_aws_partition" {
+  command = plan
+
+  variables {
+    deployment_type              = "eks"
+    region                       = "us-gov-west-1"
+    existing_monitoring_role_arn = "arn:aws-us-gov:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-gov-west-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  expect_failures = [var.existing_monitoring_role_arn]
+}
+
+run "rejects_a_malformed_monitoring_role_arn" {
+  command = plan
+
+  variables {
+    deployment_type              = "eks"
+    region                       = "us-east-1"
+    existing_monitoring_role_arn = "sb-native-db-enhanced-monitoring"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  expect_failures = [var.existing_monitoring_role_arn]
 }

--- a/modules/native-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/native-db-prereqs/tests/observability.tftest.hcl
@@ -137,6 +137,14 @@ run "grants_native_database_observability_permissions" {
   }
 
   assert {
+    condition = (
+      aws_iam_role_policy_attachment.lifecycle_worker_observability["opa1"].role == local.agent_role_names["opa1"] &&
+      aws_iam_role_policy_attachment.lifecycle_worker_observability["opa1"].policy_arn == aws_iam_policy.lifecycle_worker_observability["opa1"].arn
+    )
+    error_message = "The observability policy must be attached to the lifecycle worker role, not merely declared."
+  }
+
+  assert {
     condition     = output.enhanced_monitoring_role_arn == local.monitoring_role_arn
     error_message = "The monitoring role ARN must be exported so operators can pass it as monitoring_role_arn to the physical modules."
   }

--- a/modules/native-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/native-db-prereqs/tests/observability.tftest.hcl
@@ -171,9 +171,9 @@ run "grants_native_database_observability_permissions" {
       one([
         for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
         statement.Condition.StringEquals["iam:PassedToService"] if statement.Sid == "PassEnhancedMonitoringRole"
-      ]) == "monitoring.rds.amazonaws.com"
+      ]) == "rds.amazonaws.com"
     )
-    error_message = "Enhanced Monitoring attach requires iam:PassRole, scoped to the shared monitoring role and to RDS monitoring alone."
+    error_message = "Enhanced Monitoring attach requires iam:PassRole scoped to the shared monitoring role, conditioned on the service RDS actually passes it as (rds.amazonaws.com, not the monitoring.rds.amazonaws.com principal that assumes it)."
   }
 
   assert {

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -76,11 +76,11 @@ variable "kms_key_arn" {
 variable "existing_monitoring_role_arn" {
   type        = string
   default     = null
-  description = "ARN of an existing account-level RDS Enhanced Monitoring role. When null, the module creates superblocks-native-db-monitoring. Set this in additional regions so every worker reuses one shared role instead of creating a second copy. The physical database modules take this ARN as monitoring_role_arn; the worker is granted iam:PassRole on it and nothing else."
+  description = "ARN of an existing account-level RDS Enhanced Monitoring role. When null, the module creates <name_prefix>-enhanced-monitoring. Set this in additional regions so every worker reuses one shared role instead of creating a second copy. The physical database modules take this ARN as monitoring_role_arn; the worker is granted iam:PassRole on it and nothing else. Setting this on a deployment that previously created the role destroys that role: any database still configured with the old ARN loses Enhanced Monitoring until the physical modules are re-pointed at the role you supply here, so re-point them first."
 
   validation {
-    condition     = var.existing_monitoring_role_arn == null || can(regex("^arn:aws[a-z-]*:iam::[0-9]{12}:role/([A-Za-z0-9+=,.@_-]+/)*superblocks-native-db-monitoring$", var.existing_monitoring_role_arn))
-    error_message = "existing_monitoring_role_arn must be a concrete IAM role ARN named superblocks-native-db-monitoring, with an optional path and no wildcards."
+    condition     = var.existing_monitoring_role_arn == null || can(regex("^arn:aws:iam::[0-9]{12}:role/([A-Za-z0-9+=,.@_-]+/)*[A-Za-z0-9+=,.@_-]+$", var.existing_monitoring_role_arn))
+    error_message = "existing_monitoring_role_arn must be a concrete IAM role ARN in the aws partition, with an optional path and no wildcards. The rest of this module hardcodes arn:aws:, so aws-us-gov and aws-cn ARNs are not supported."
   }
 }
 

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -73,6 +73,17 @@ variable "kms_key_arn" {
   description = "ARN of the KMS key for the OpenTofu state bucket. When provided, the bucket is configured with SSE-KMS using this key and IAM KMS permissions are scoped to it. When null, the bucket uses the AWS account default encryption and IAM KMS permissions fall back to Resource:* conditioned on aws:CalledVia s3.amazonaws.com."
 }
 
+variable "existing_monitoring_role_arn" {
+  type        = string
+  default     = null
+  description = "ARN of an existing account-level RDS Enhanced Monitoring role. When null, the module creates superblocks-native-db-monitoring. Set this in additional regions so every worker reuses one shared role instead of creating a second copy. The physical database modules take this ARN as monitoring_role_arn; the worker is granted iam:PassRole on it and nothing else."
+
+  validation {
+    condition     = var.existing_monitoring_role_arn == null || can(regex("^arn:aws[a-z-]*:iam::[0-9]{12}:role/([A-Za-z0-9+=,.@_-]+/)*superblocks-native-db-monitoring$", var.existing_monitoring_role_arn))
+    error_message = "existing_monitoring_role_arn must be a concrete IAM role ARN named superblocks-native-db-monitoring, with an optional path and no wildcards."
+  }
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
## Summary

The Native DB physical modules now create CloudWatch log groups and attach Enhanced Monitoring by default ([terraform-superblocks-databases#19](https://github.com/superblocksteam/terraform-superblocks-databases/pull/19)). This prerequisites module is what creates the lifecycle worker role customers install, and until it grants the matching permissions every physical provision fails with `AccessDenied` the moment those defaults are live. We had to apply the same grants by hand in our sandbox account after the internal terraform PR for them closed as inert; this puts that contract into the customer-facing module so the next account does not need a manual apply.

## Context

[`monitoring_role_arn`](https://github.com/superblocksteam/terraform-superblocks-databases/blob/main/modules/aws-rds-managed-instance/_variables.tf) is required unless `monitoring_interval` is `0`. The physical modules deliberately never create that role — one account-level role is reused by every database so the worker never needs `iam:CreateRole`. Whoever enables Enhanced Monitoring still has to hold a scoped `iam:PassRole` on it, and the explicit log groups need CloudWatch Logs write access inside the `sb-*` namespace.

The earlier attempt lived in [terraform#1172](https://github.com/superblocksteam/terraform/pull/1172) against the internal `native-db-lifecycle` tfroot. That tfroot sets `create_worker_iam = false` in the sandbox, so the HCL never materializes there. The durable home for this policy is this module.

## What changed

`modules/native-db-prereqs` now creates one account-level Enhanced Monitoring role with confused-deputy protection, attaches the AWS-managed `AmazonRDSEnhancedMonitoringRole` policy, and grants every lifecycle worker an observability policy that can manage the `sb-*` CloudWatch log groups and pass that single monitoring role to RDS monitoring.

The role name derives from `name_prefix` like every other resource this module names, so the default install gets `sb-native-db-enhanced-monitoring`:

```hcl
resource "aws_iam_role" "enhanced_monitoring" {
  name = "${var.name_prefix}-enhanced-monitoring"
  assume_role_policy = jsonencode({
    Statement = [{
      Principal = { Service = "monitoring.rds.amazonaws.com" }
      Action    = "sts:AssumeRole"
      Condition = {
        ArnLike      = { "aws:SourceArn" = ["arn:aws:rds:*:<account>:cluster:sb-*", "arn:aws:rds:*:<account>:db:sb-*"] }
        StringEquals = { "aws:SourceAccount" = "<account>" }
      }
    }]
  })
}
```

The worker policy keeps `logs:DescribeLogGroups` on `*` in its own statement — AWS will not authorize that action against a log-group ARN, so bundling it with the scoped Create/Delete/Tag actions would silently fail provider refreshes. `iam:PassRole` is conditioned on `iam:PassedToService = monitoring.rds.amazonaws.com`.

IAM role names are account-global, so a second region in the same account has to reuse the first region's role rather than create its own. Note that setting `existing_monitoring_role_arn` on a deployment that previously created the role destroys that role, so re-point the physical modules before flipping it:

```hcl
module "native_db_prereqs" {
  source                       = "superblocksteam/superblocks/aws//modules/native-db-prereqs"
  existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
  # ...
}
```

That input takes `aws`-partition ARNs only. Every ARN this module builds hardcodes `arn:aws:`, including the managed-policy ARN and the RDS `SourceArn` patterns above, so a GovCloud or China role would pass an ARN-shape check and then silently fail to be assumable:

```text
existing_monitoring_role_arn must be a concrete IAM role ARN in the aws
partition, with an optional path and no wildcards. The rest of this module
hardcodes arn:aws:, so aws-us-gov and aws-cn ARNs are not supported.
```

The module exports `enhanced_monitoring_role_arn` so operators can pass it through as `databaseLifecycle.physicalModuleInputs.monitoring_role_arn` (Helm) or into `modules/native-db` once that wiring lands. Both examples surface the new output. A mocked OpenTofu contract test covers the create path, the existing-role reuse path, and both rejected-ARN cases.

Linear: ENG-5014