### PR TITLE
feat(native-db): default to Aurora Serverless v2, align worker config, fix connector IAM (ENG-4959, ENG-5117)

### DIFF
--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -19,8 +19,10 @@ module "native_db_prereqs" {
   # IAM roles and must be unique per AWS account (max 15 characters).
   agents = {
     opa1 = {
-      # Agent tags namespace the DB users provisioned by this OPA.
-      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Agent tags namespace the DB users provisioned by this OPA. Each tag is
+      # hashed into a profile token — the first 16 hex characters of SHA-256 over
+      # the lowercased tag — so "nonprod" creates runtime users as
+      # sbndb_6fdc0c6b96ee8a74_<application-token>_runtime.
       # Must match the superblocks_agent_tags configured for this OPA.
       agent_tags = ["nonprod", "production"]
 

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -74,6 +74,7 @@ module "native_db_opa1" {
   source = "../../modules/native-db"
 
   # Wired directly from native-db-prereqs outputs.
+  agent_name         = "opa1"
   connector_role_arn = module.native_db_prereqs.agents["opa1"].connector_role_arn
   agent_tags         = module.native_db_prereqs.agents["opa1"].agent_tags
   state_bucket_name  = module.native_db_prereqs.state_bucket_name

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -62,12 +62,64 @@ module "native_db_prereqs" {
   }
 }
 
+# Step 2 of 2: generate the environment variables the OPA ECS container needs
+# to run the lifecycle worker. Call this once per OPA. Pass ecs_env_vars as
+# superblocks_agent_environment_variables in the terraform-aws-superblocks root
+# module that manages the ECS task definition.
+#
+# Registry path (when consuming from Terraform Registry):
+#   source  = "superblocksteam/superblocks/aws//modules/native-db"
+#   version = "~>1.0"
+module "native_db_opa1" {
+  source = "../../modules/native-db"
+
+  # Wired directly from native-db-prereqs outputs.
+  connector_role_arn = module.native_db_prereqs.agents["opa1"].connector_role_arn
+  agent_tags         = module.native_db_prereqs.agents["opa1"].agent_tags
+  state_bucket_name  = module.native_db_prereqs.state_bucket_name
+
+  region = "us-east-1"
+
+  # Namespaces this OPA's OpenTofu state within the shared S3 bucket.
+  # Must be unique per OPA. Using the agent name as a suffix is recommended.
+  key_prefix = "native-db/opa1"
+
+  physical_module_inputs = {
+    instance_class    = "db.t4g.medium"
+    allocated_storage = 100
+
+    vpc_id = "vpc-0123456789abcdef0"
+
+    # Subnets in at least two Availability Zones — required by the DB subnet group.
+    subnet_ids = [
+      "subnet-0000000000000001",
+      "subnet-0000000000000002",
+    ]
+
+    # Propagate the same tags applied to IAM and S3 resources above.
+    tags = module.native_db_prereqs.tags
+
+    # Optional: restrict which security groups (e.g. your OPA task SG) can reach
+    # the RDS instances over port 5432.
+    # source_security_group_ids = ["sg-0123456789abcdef0"]
+  }
+
+  # Optional: override the pool capacity. Default is 100 logical databases per
+  # physical RDS instance before a new instance is automatically provisioned.
+  # pool = { max_databases = 50 }
+}
+
 output "agents" {
   value       = module.native_db_prereqs.agents
-  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (set as ECS task role ARN) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+  description = "Per-agent outputs: lifecycle_worker_role_arn (set as the ECS task role ARN), connector_role_arn, and agent_tags."
 }
 
 output "state_bucket_name" {
   value       = module.native_db_prereqs.state_bucket_name
   description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}
+
+output "opa1_ecs_env_vars" {
+  value       = module.native_db_opa1.ecs_env_vars
+  description = "Pass as superblocks_agent_environment_variables in the terraform-aws-superblocks root module for the opa1 ECS task definition."
 }

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -97,11 +97,7 @@ module "native_db_opa1" {
     # = 2 keeps a second warm instance for immediate failover.
     #
     # min_acu = 0 lets a cluster pause when idle. Use it for nonprod, not
-    # production. To run fixed instances instead of Serverless v2, replace this
-    # block with `deployment = { provisioned = { instance_class =
-    # "db.r6g.large", instance_count = 2 } }`. For a standalone RDS instance
-    # rather than an Aurora cluster, omit `deployment` and set
-    # `allocated_storage` and `instance_class` instead.
+    # production.
     deployment = {
       serverless_v2 = {
         instance_count = 2
@@ -109,6 +105,18 @@ module "native_db_opa1" {
         min_acu        = 2
       }
     }
+
+    # Aurora with fixed instances instead of Serverless v2:
+    # deployment = {
+    #   provisioned = {
+    #     instance_class = "db.r6g.large"
+    #     instance_count = 2
+    #   }
+    # }
+
+    # Standalone RDS instead of an Aurora cluster (omit deployment above):
+    # allocated_storage = 100
+    # instance_class    = "db.t4g.medium"
 
     vpc_id = "vpc-0123456789abcdef0"
 

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -62,10 +62,13 @@ module "native_db_prereqs" {
   }
 }
 
-# Step 2 of 2: generate the environment variables the OPA ECS container needs
-# to run the lifecycle worker. Call this once per OPA. Pass ecs_env_vars as
-# superblocks_agent_environment_variables in the terraform-aws-superblocks root
-# module that manages the ECS task definition.
+# Step 2 of 2: generate the runtime configuration the OPA ECS container needs to
+# run the lifecycle worker. Call this once per OPA. In the
+# terraform-aws-superblocks root module that manages the ECS task definition,
+# pass ecs_env_vars as superblocks_agent_environment_variables and
+# superblocks_agent_tags as superblocks_agent_tags — the worker reads the
+# profiles it serves from those tags, so taking them from this module keeps them
+# from drifting away from the databases it is configured to provision.
 #
 # Registry path (when consuming from Terraform Registry):
 #   source  = "superblocksteam/superblocks/aws//modules/native-db"
@@ -86,8 +89,24 @@ module "native_db_opa1" {
   key_prefix = "native-db/opa1"
 
   physical_module_inputs = {
-    instance_class    = "db.t4g.medium"
-    allocated_storage = 100
+    # Aurora Serverless v2 is the default: capacity scales between min_acu and
+    # max_acu with no instance class to size. Omit `deployment` entirely to
+    # accept the module defaults, or state the range you want. instance_count
+    # = 2 keeps a second warm instance for immediate failover.
+    #
+    # min_acu = 0 lets a cluster pause when idle. Use it for nonprod, not
+    # production. To run fixed instances instead of Serverless v2, replace this
+    # block with `deployment = { provisioned = { instance_class =
+    # "db.r6g.large", instance_count = 2 } }`. For a standalone RDS instance
+    # rather than an Aurora cluster, omit `deployment` and set
+    # `allocated_storage` and `instance_class` instead.
+    deployment = {
+      serverless_v2 = {
+        instance_count = 2
+        max_acu        = 32
+        min_acu        = 2
+      }
+    }
 
     vpc_id = "vpc-0123456789abcdef0"
 
@@ -101,12 +120,12 @@ module "native_db_opa1" {
     tags = module.native_db_prereqs.tags
 
     # Optional: restrict which security groups (e.g. your OPA task SG) can reach
-    # the RDS instances over port 5432.
+    # the database over port 5432.
     # source_security_group_ids = ["sg-0123456789abcdef0"]
   }
 
   # Optional: override the pool capacity. Default is 100 logical databases per
-  # physical RDS instance before a new instance is automatically provisioned.
+  # Aurora cluster before a new cluster is automatically provisioned.
   # pool = { max_databases = 50 }
 }
 
@@ -123,4 +142,9 @@ output "state_bucket_name" {
 output "opa1_ecs_env_vars" {
   value       = module.native_db_opa1.ecs_env_vars
   description = "Pass as superblocks_agent_environment_variables in the terraform-aws-superblocks root module for the opa1 ECS task definition."
+}
+
+output "opa1_superblocks_agent_tags" {
+  value       = module.native_db_opa1.superblocks_agent_tags
+  description = "Pass as superblocks_agent_tags in the terraform-aws-superblocks root module for the opa1 ECS task definition."
 }

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -19,8 +19,10 @@ module "native_db_prereqs" {
   # IAM roles and must be unique per AWS account (max 15 characters).
   agents = {
     opa1 = {
-      # Agent tags namespace the DB users provisioned by this OPA.
-      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Agent tags namespace the DB users provisioned by this OPA. Each tag is
+      # hashed into a profile token — the first 16 hex characters of SHA-256 over
+      # the lowercased tag — so "nonprod" creates runtime users as
+      # sbndb_6fdc0c6b96ee8a74_<application-token>_runtime.
       # Must match the superblocks_agent_tags configured for this OPA.
       agent_tags = ["nonprod", "production"]
 

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -121,6 +121,12 @@ module "native_db_opa1" {
     # Propagate the same tags applied to IAM and S3 resources above.
     tags = module.native_db_prereqs.tags
 
+    # Enhanced Monitoring runs at 60 seconds by default, and RDS only accepts
+    # that alongside a role it can assume. Replace this with the prerequisite
+    # stack's enhanced_monitoring_role_arn output, or set monitoring_interval = 0
+    # to turn Enhanced Monitoring off.
+    monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+
     # Optional: restrict which security groups (e.g. your OPA task SG) can reach
     # the database over port 5432.
     # source_security_group_ids = ["sg-0123456789abcdef0"]

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -27,6 +27,21 @@ locals {
   }
 
   # ----------------------------------------------------------------
+  # Profile tokens.
+  #
+  # Every database and runtime user the lifecycle worker creates is named
+  # sbndb_<profile_token>_<application_token>[_runtime], where profile_token is
+  # the first 16 hex characters of SHA-256 over the lowercased data tag. IAM
+  # grants must be written against that token, not the tag itself.
+  #
+  #   printf '%s' nonprod | shasum -a 256 | cut -c1-16  =>  6fdc0c6b96ee8a74
+  # ----------------------------------------------------------------
+  profile_tokens = {
+    for tag in distinct(flatten([for agent in values(var.agents) : agent.agent_tags])) :
+    tag => substr(sha256(lower(tag)), 0, 16)
+  }
+
+  # ----------------------------------------------------------------
   # Tagging
   # ----------------------------------------------------------------
   managed_by_tag = "superblocks-native-database-lifecycle"
@@ -860,8 +875,11 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_secrets" {
 # Assumed at query time by the OPA serving code to generate an RDS IAM
 # authentication token. Trusts only that agent's lifecycle worker role(s).
 #
-# Policy contains one rds-db:connect statement per profile, scoping
-# access to DB users in the sbndb_{profile}_*_runtime namespace.
+# Policy contains one rds-db:connect statement per data tag, scoping access to
+# DB users in the sbndb_{profile_token}_*_runtime namespace. The lifecycle
+# worker derives that token from the tag rather than using the tag itself, so a
+# grant written against the bare tag matches no DB user and every query fails
+# with AccessDenied.
 #
 # Role name format: superblocks-native-db-connector-{agent_name}
 # "superblocks-native-db-connector" is a reserved prefix: the Superblocks
@@ -900,8 +918,8 @@ resource "aws_iam_policy" "connector" {
         Effect = "Allow"
         Action = "rds-db:connect"
         Resource = [
-          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:cluster-*/sbndb_${tag}_*_runtime",
-          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:db-*/sbndb_${tag}_*_runtime",
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:cluster-*/sbndb_${local.profile_tokens[tag]}_*_runtime",
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:db-*/sbndb_${local.profile_tokens[tag]}_*_runtime",
         ]
       }
     ]

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -3,12 +3,18 @@ output "agents" {
     for k in keys(var.agents) : k => {
       lifecycle_worker_role_arn = local.agent_role_arns[k]
       connector_role_arn        = aws_iam_role.connector[k].arn
+      agent_tags                = var.agents[k].agent_tags
     }
   }
-  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role — set as the ECS task role or annotate the EKS service account) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role), connector_role_arn (pass as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN), and agent_tags (pass as agent_tags to the native-db module)."
 }
 
 output "state_bucket_name" {
   value       = aws_s3_bucket.tofu_state.id
   description = "Name of the S3 bucket used for OpenTofu state, shared across all agents in this module invocation."
+}
+
+output "tags" {
+  value       = var.tags
+  description = "Tags applied to all resources created by this module. Pass to the native-db module's physical_module_inputs.tags to tag RDS instances with the same values."
 }

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -15,6 +15,6 @@ output "state_bucket_name" {
 }
 
 output "tags" {
-  value       = var.tags
+  value       = local.tags
   description = "Tags applied to all resources created by this module. Pass to the native-db module's physical_module_inputs.tags to tag RDS instances with the same values."
 }

--- a/modules/native-db-prereqs/tests/agent_names.tftest.hcl
+++ b/modules/native-db-prereqs/tests/agent_names.tftest.hcl
@@ -1,0 +1,65 @@
+# Agent names (the agents map keys) are embedded in IAM role names. Restrict
+# them to lowercase alphanumeric so a later resource that rejects hyphens or
+# underscores does not force a rename after databases exist.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock"
+    }
+  }
+}
+
+variables {
+  deployment_type = "fargate"
+  region          = "us-east-1"
+
+  agents = {
+    opa1 = {
+      agent_tags = ["nonprod"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+}
+
+run "agent_names_reject_hyphens" {
+  command = plan
+
+  variables {
+    agents = {
+      "opa-1" = {
+        agent_tags = ["nonprod"]
+        vpc_id     = "vpc-0123456789abcdef0"
+      }
+    }
+  }
+
+  expect_failures = [var.agents]
+}
+
+run "agent_names_reject_underscores" {
+  command = plan
+
+  variables {
+    agents = {
+      "opa_1" = {
+        agent_tags = ["nonprod"]
+        vpc_id     = "vpc-0123456789abcdef0"
+      }
+    }
+  }
+
+  expect_failures = [var.agents]
+}

--- a/modules/native-db-prereqs/tests/connector_policy.tftest.hcl
+++ b/modules/native-db-prereqs/tests/connector_policy.tftest.hcl
@@ -84,3 +84,24 @@ run "the_connect_grant_names_hashed_profile_tokens" {
     error_message = "Statement Sids must name the data tag they came from."
   }
 }
+
+run "the_tags_output_matches_what_the_module_stamps" {
+  command = plan
+
+  variables {
+    tags = { Environment = "production" }
+  }
+
+  # The example forwards this output into physical_module_inputs.tags, so it has
+  # to be the merged set the module puts on its own resources, not the caller's
+  # raw input.
+  assert {
+    condition     = tomap(output.tags) == aws_iam_role.lifecycle_worker["prod"].tags
+    error_message = "The tags output must equal the tags the module applies to the resources it creates."
+  }
+
+  assert {
+    condition     = output.tags == { Environment = "production", ManagedBy = "superblocks-native-database-lifecycle" }
+    error_message = "The tags output must merge ManagedBy over the caller's tags."
+  }
+}

--- a/modules/native-db-prereqs/tests/connector_policy.tftest.hcl
+++ b/modules/native-db-prereqs/tests/connector_policy.tftest.hcl
@@ -1,0 +1,86 @@
+# The connector role's rds-db:connect grant has to name the DB users the
+# lifecycle worker actually creates. The worker derives the profile segment of
+# every database and runtime user from the data tag by hashing it — first 16 hex
+# characters of SHA-256 over the lowercased tag — so a policy written against the
+# bare tag matches nothing and every query fails with AccessDenied.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  # Generated mock IDs are not ARN-shaped, and the provider validates the
+  # policy_arn it is handed before any assertion runs.
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock"
+    }
+  }
+}
+
+variables {
+  deployment_type = "fargate"
+  region          = "us-east-1"
+
+  agents = {
+    prod = {
+      agent_tags = ["nonprod", "production"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+}
+
+run "the_connect_grant_names_hashed_profile_tokens" {
+  command = plan
+
+  # printf '%s' nonprod | shasum -a 256 | cut -c1-16
+  assert {
+    condition = contains(
+      flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]),
+      "arn:aws:rds-db:us-east-1:123456789012:dbuser:cluster-*/sbndb_6fdc0c6b96ee8a74_*_runtime"
+    )
+    error_message = "The Aurora grant for the nonprod tag must name the hashed profile token 6fdc0c6b96ee8a74."
+  }
+
+  assert {
+    condition = contains(
+      flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]),
+      "arn:aws:rds-db:us-east-1:123456789012:dbuser:db-*/sbndb_6fdc0c6b96ee8a74_*_runtime"
+    )
+    error_message = "The standalone RDS grant for the nonprod tag must name the hashed profile token 6fdc0c6b96ee8a74."
+  }
+
+  # printf '%s' production | shasum -a 256 | cut -c1-16
+  assert {
+    condition = contains(
+      flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]),
+      "arn:aws:rds-db:us-east-1:123456789012:dbuser:cluster-*/sbndb_ab8e18ef4ebebedd_*_runtime"
+    )
+    error_message = "The Aurora grant for the production tag must name the hashed profile token ab8e18ef4ebebedd."
+  }
+
+  assert {
+    condition = alltrue([
+      for resource in flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]) :
+      can(regex("/sbndb_[0-9a-f]{16}_\\*_runtime$", resource))
+    ])
+    error_message = "Every grant must target the sbndb_<16 hex>_<application token>_runtime namespace the worker creates; a bare data tag matches no DB user."
+  }
+
+  # The Sid stays human-readable so an operator can map a statement back to the
+  # tag that produced it — only the DB user namespace is hashed.
+  assert {
+    condition = [
+      for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Sid
+    ] == ["ConnectTagNonprod", "ConnectTagProduction"]
+    error_message = "Statement Sids must name the data tag they came from."
+  }
+}

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -36,8 +36,8 @@ variable "agents" {
   }
 
   validation {
-    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9_-]{1,15}$", k))])
-    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters, hyphens, or underscores."
+    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9]{1,15}$", k))])
+    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters."
   }
 
   validation {

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -36,8 +36,8 @@ variable "agents" {
   }
 
   validation {
-    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9-]{1,15}$", k))])
-    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters or hyphens."
+    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9_-]{1,15}$", k))])
+    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters, hyphens, or underscores."
   }
 
   validation {

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -148,6 +148,10 @@ locals {
       value = "${local.logical_module_source},${local.physical_module_source}"
     },
     {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_AGENT_NAME"
+      value = var.agent_name
+    },
+    {
       name  = "SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN"
       value = var.connector_role_arn
     },

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -4,11 +4,31 @@ locals {
   # Module sources relative to the dispatch working directory. The Superblocks
   # OPA image vendors these modules at a fixed path — customers do not configure
   # them.
-  logical_module_source  = "./modules/postgres-managed-database"
-  physical_module_source = "./modules/aws-rds-managed-instance"
+  logical_module_source = "./modules/postgres-managed-database"
+
+  # Aurora is the default physical engine, so a caller who states only where the
+  # database goes gets a Serverless v2 cluster. Standalone RDS is opt-in through
+  # the instance-sizing inputs, which Aurora does not accept; the variable's
+  # validation requires them together and forbids mixing them with deployment.
+  rds_selected = (
+    var.physical_module_inputs.allocated_storage != null ||
+    var.physical_module_inputs.instance_class != null
+  )
+
+  physical_module_source = (
+    local.rds_selected
+    ? "./modules/aws-rds-managed-instance"
+    : "./modules/aws-aurora-managed-cluster"
+  )
 
   # SSL cert path baked into the Superblocks OPA image.
   ssl_root_cert = "/etc/ssl/certs/aws-rds-global-bundle.pem"
+
+  # Agent tags carry the profiles this OPA serves. The worker reads them from
+  # SUPERBLOCKS_ORCHESTRATOR_AGENT_TAGS, which the root module renders from its
+  # own superblocks_agent_tags input — so this module derives the string and
+  # exposes it for wiring rather than emitting a second copy of that env var.
+  superblocks_agent_tags = join(",", [for tag in var.agent_tags : "profile:${tag}"])
 
   # S3 backend base config shared by all operations. The per-operation `key`
   # is set via merge() below so that logical and physical state land under
@@ -20,17 +40,14 @@ locals {
     use_lockfile = true
   }
 
-  # Physical module inputs forwarded to ensure_physical_database_instance.
-  # publicly_accessible is always false — the lifecycle worker IAM policy
-  # enforces this at create time regardless of module input.
-  physical_inputs = {
-    allocated_storage         = var.physical_module_inputs.allocated_storage
+  # Physical inputs both modules accept. publicly_accessible is always false —
+  # the lifecycle worker IAM policy enforces this at create time regardless of
+  # module input.
+  physical_inputs_shared = {
     allowed_cidr_blocks       = var.physical_module_inputs.allowed_cidr_blocks
     backup_retention_period   = var.physical_module_inputs.backup_retention_period
     delete_automated_backups  = var.physical_module_inputs.delete_automated_backups
     deletion_protection       = var.physical_module_inputs.deletion_protection
-    instance_class            = var.physical_module_inputs.instance_class
-    multi_az                  = var.physical_module_inputs.multi_az
     publicly_accessible       = false
     skip_final_snapshot       = var.physical_module_inputs.skip_final_snapshot
     source_security_group_ids = var.physical_module_inputs.source_security_group_ids
@@ -39,11 +56,51 @@ locals {
     vpc_id                    = var.physical_module_inputs.vpc_id
   }
 
+  # An omitted deployment forwards an empty serverless_v2 object so the Aurora
+  # module applies its own Serverless v2 defaults rather than this module
+  # restating a capacity range it would then have to keep in sync.
+  aurora_deployment_json = (
+    var.physical_module_inputs.deployment == null
+    ? jsonencode({ serverless_v2 = {} })
+    : jsonencode(var.physical_module_inputs.deployment)
+  )
+
+  # Aurora and RDS take disjoint capacity arguments and each fails the plan with
+  # "Unsupported argument" on the other's, so only the selected set is
+  # forwarded. The chosen set round-trips through JSON because a conditional
+  # between the two object types would unify them and silently drop keys.
+  physical_inputs_json = (
+    local.rds_selected
+    ? jsonencode(merge(local.physical_inputs_shared,
+      {
+        allocated_storage = var.physical_module_inputs.allocated_storage
+        instance_class    = var.physical_module_inputs.instance_class
+      },
+      # An unstated multi_az is dropped rather than forwarded as null so the RDS
+      # module's own default governs it.
+      { for name, value in { multi_az = var.physical_module_inputs.multi_az } : name => value if value != null },
+    ))
+    : jsonencode(merge(local.physical_inputs_shared, {
+      deployment = jsondecode(local.aurora_deployment_json)
+    }))
+  )
+
+  # Physical module inputs forwarded to ensure_physical_database_instance.
+  physical_inputs = jsondecode(local.physical_inputs_json)
+
   # Logical module inputs shared by ensure_database and retire_database.
+  #
+  # auth_mode is absent deliberately: the worker sends aws_iam_role itself, and
+  # the logical module no longer accepts the input from operators.
+  #
+  # connector_role_arn is not authored by the caller either — it has one legal
+  # value per OPA and arrives as a module input — but it must still reach the
+  # logical module, because the worker only advertises managed IAM when the
+  # module inputs carry the connector role it was configured with. The Helm
+  # path derives it into these inputs the same way.
   logical_inputs = {
-    auth_mode          = "aws_iam_role"
-    connector_role_arn = var.connector_role_arn
-    postgres_sslmode   = "verify-full"
+    connector_role_arn   = var.connector_role_arn
+    postgres_sslmode     = "verify-full"
     postgres_sslrootcert = local.ssl_root_cert
   }
 
@@ -102,16 +159,13 @@ locals {
     }
   }
 
-  # One entry covers all profiles this OPA serves. Profiles must be explicit
-  # (no wildcard) and must match the agent_tags declared in native-db-prereqs.
+  # One configuration per OPA: engines and operations sit at the document root.
+  # The profiles this OPA serves are deliberately absent — they are declared
+  # once as agent tags, and the worker rejects a profiles key here outright so
+  # the two can never disagree.
   lifecycle_config = {
-    entries = [
-      {
-        profiles   = var.agent_tags
-        engines    = ["postgres"]
-        operations = local.lifecycle_operations
-      }
-    ]
+    engines    = ["postgres"]
+    operations = local.lifecycle_operations
   }
 
   # Scope the secrets refresolver to only RDS-managed master secrets in this
@@ -139,10 +193,11 @@ locals {
       name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_POLL_INTERVAL"
       value = "5s"
     },
-    {
-      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES"
-      value = "aws_db_instance,aws_db_subnet_group,aws_secretsmanager_secret,aws_secretsmanager_secret_version,aws_security_group,aws_security_group_rule,postgresql_database,postgresql_default_privileges,postgresql_grant,postgresql_role,postgresql_schema,random_id,terraform_data"
-    },
+    # SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES is deliberately
+    # unset. The worker's own default mirrors the resource graph of the modules
+    # it ships, and an operator-supplied list replaces that default outright
+    # rather than extending it — so a hardcoded list here would fail the first
+    # plan that creates a resource type a newer module release introduced.
     {
       name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
       value = "${local.logical_module_source},${local.physical_module_source}"

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -113,7 +113,6 @@ locals {
     backend = merge(local.s3_backend_base, {
       key = "${var.key_prefix}/logical/{{profile}}/{{resource_key}}.tfstate"
     })
-    credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
     moduleSelectors = {
       postgres = {
         source = local.logical_module_source
@@ -141,7 +140,6 @@ locals {
         backend = merge(local.s3_backend_base, {
           key = "${var.key_prefix}/physical/{{profile}}/{{resource_key}}.tfstate"
         })
-        credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
         moduleSelectors = {
           postgres = {
             source = local.physical_module_source

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -194,7 +194,7 @@ locals {
     },
     {
       name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_POLL_INTERVAL"
-      value = "5s"
+      value = "30s"
     },
     # SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES is deliberately
     # unset. The worker's own default mirrors the resource graph of the modules

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -1,9 +1,10 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  # Module sources relative to the dispatch working directory. The Superblocks
-  # OPA image vendors these modules at a fixed path — customers do not configure
-  # them.
+  # Module sources relative to the dispatch working directory. The OPA image
+  # vendors these modules at fixed paths; this module pins those paths and does
+  # not expose them as inputs. Operators who need a different source write their
+  # own SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG instead of using this module.
   logical_module_source = "./modules/postgres-managed-database"
 
   # Aurora is the default physical engine, so a caller who states only where the
@@ -110,7 +111,7 @@ locals {
   # logical backend key and module).
   logical_terraform = {
     backend = merge(local.s3_backend_base, {
-      key = "${var.key_prefix}/logical/{{environment}}/{{profile}}/{{resource_key}}.tfstate"
+      key = "${var.key_prefix}/logical/{{profile}}/{{resource_key}}.tfstate"
     })
     credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
     moduleSelectors = {
@@ -138,7 +139,7 @@ locals {
       backend = "terraform"
       terraform = {
         backend = merge(local.s3_backend_base, {
-          key = "${var.key_prefix}/physical/{{environment}}/{{profile}}/{{resource_key}}.tfstate"
+          key = "${var.key_prefix}/physical/{{profile}}/{{resource_key}}.tfstate"
         })
         credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
         moduleSelectors = {

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -1,0 +1,175 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Module sources relative to the dispatch working directory. The Superblocks
+  # OPA image vendors these modules at a fixed path — customers do not configure
+  # them.
+  logical_module_source  = "./modules/postgres-managed-database"
+  physical_module_source = "./modules/aws-rds-managed-instance"
+
+  # SSL cert path baked into the Superblocks OPA image.
+  ssl_root_cert = "/etc/ssl/certs/aws-rds-global-bundle.pem"
+
+  # S3 backend base config shared by all operations. The per-operation `key`
+  # is set via merge() below so that logical and physical state land under
+  # separate prefixes in the same bucket.
+  s3_backend_base = {
+    stateBackend = "s3"
+    bucket       = var.state_bucket_name
+    region       = var.region
+    use_lockfile = true
+  }
+
+  # Physical module inputs forwarded to ensure_physical_database_instance.
+  # publicly_accessible is always false — the lifecycle worker IAM policy
+  # enforces this at create time regardless of module input.
+  physical_inputs = {
+    allocated_storage         = var.physical_module_inputs.allocated_storage
+    allowed_cidr_blocks       = var.physical_module_inputs.allowed_cidr_blocks
+    backup_retention_period   = var.physical_module_inputs.backup_retention_period
+    delete_automated_backups  = var.physical_module_inputs.delete_automated_backups
+    deletion_protection       = var.physical_module_inputs.deletion_protection
+    instance_class            = var.physical_module_inputs.instance_class
+    multi_az                  = var.physical_module_inputs.multi_az
+    publicly_accessible       = false
+    skip_final_snapshot       = var.physical_module_inputs.skip_final_snapshot
+    source_security_group_ids = var.physical_module_inputs.source_security_group_ids
+    subnet_ids                = var.physical_module_inputs.subnet_ids
+    tags                      = var.physical_module_inputs.tags
+    vpc_id                    = var.physical_module_inputs.vpc_id
+  }
+
+  # Logical module inputs shared by ensure_database and retire_database.
+  logical_inputs = {
+    auth_mode          = "aws_iam_role"
+    connector_role_arn = var.connector_role_arn
+    postgres_sslmode   = "verify-full"
+    postgres_sslrootcert = local.ssl_root_cert
+  }
+
+  # Terraform config shared by ensure_database and retire_database (same
+  # logical backend key and module).
+  logical_terraform = {
+    backend = merge(local.s3_backend_base, {
+      key = "${var.key_prefix}/logical/{{environment}}/{{profile}}/{{resource_key}}.tfstate"
+    })
+    credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
+    moduleSelectors = {
+      postgres = {
+        source = local.logical_module_source
+        inputs = local.logical_inputs
+      }
+    }
+  }
+
+  lifecycle_operations = {
+    ensure_database = {
+      backend = "terraform"
+      physicalDatabase = {
+        mode               = "shared_pool"
+        provisionOperation = "ensure_physical_database_instance"
+        onExhausted        = "provision"
+        capacityMax        = var.pool.max_databases
+        securityClass      = "standard"
+      }
+      terraform = local.logical_terraform
+    }
+
+    ensure_physical_database_instance = {
+      backend = "terraform"
+      terraform = {
+        backend = merge(local.s3_backend_base, {
+          key = "${var.key_prefix}/physical/{{environment}}/{{profile}}/{{resource_key}}.tfstate"
+        })
+        credentialResolver = { runtime = "aws_secrets_manager", region = var.region }
+        moduleSelectors = {
+          postgres = {
+            source = local.physical_module_source
+            inputs = local.physical_inputs
+          }
+        }
+      }
+    }
+
+    # Schema migrations run natively inside the OPA process — no Terraform.
+    migrate_schema = { backend = "native_runner" }
+
+    # retire_database reuses the logical Terraform root so tofu destroy targets
+    # the same state as ensure_database.
+    retire_database = {
+      backend   = "terraform"
+      terraform = local.logical_terraform
+    }
+  }
+
+  # One entry covers all profiles this OPA serves. Profiles must be explicit
+  # (no wildcard) and must match the agent_tags declared in native-db-prereqs.
+  lifecycle_config = {
+    entries = [
+      {
+        profiles   = var.agent_tags
+        engines    = ["postgres"]
+        operations = local.lifecycle_operations
+      }
+    ]
+  }
+
+  # Scope the secrets refresolver to only RDS-managed master secrets in this
+  # account and region. The lifecycle worker reads these to connect as the
+  # admin user when provisioning logical databases.
+  allowed_ref_prefixes = [
+    "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-",
+    "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-",
+  ]
+
+  ecs_env_vars = [
+    {
+      name  = "SUPERBLOCKS_ORCHESTRATOR_DATABASE_LIFECYCLE_WORKER_ENABLED"
+      value = "true"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ROOT_DIR"
+      value = "/var/lib/superblocks/database-lifecycle"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_TERRAFORM_BIN"
+      value = "/usr/local/bin/tofu"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_POLL_INTERVAL"
+      value = "5s"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES"
+      value = "aws_db_instance,aws_db_subnet_group,aws_secretsmanager_secret,aws_secretsmanager_secret_version,aws_security_group,aws_security_group_rule,postgresql_database,postgresql_default_privileges,postgresql_grant,postgresql_role,postgresql_schema,random_id,terraform_data"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
+      value = "${local.logical_module_source},${local.physical_module_source}"
+    },
+    {
+      name  = "SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN"
+      value = var.connector_role_arn
+    },
+    {
+      name  = "SUPERBLOCKS_POSTGRES_IAM_ALLOWED_ROLE_ARN_PREFIXES"
+      value = jsonencode([var.connector_role_arn])
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_SSL_MODE"
+      value = "verify-full"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_SSL_ROOT_CERT"
+      value = local.ssl_root_cert
+    },
+    {
+      name  = "SUPERBLOCKS_SECRETS_REFRESOLVER_ALLOWED_REF_PREFIXES"
+      value = join(",", local.allowed_ref_prefixes)
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+      value = jsonencode(local.lifecycle_config)
+    },
+  ]
+}

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -48,6 +48,8 @@ locals {
     backup_retention_period   = var.physical_module_inputs.backup_retention_period
     delete_automated_backups  = var.physical_module_inputs.delete_automated_backups
     deletion_protection       = var.physical_module_inputs.deletion_protection
+    monitoring_interval       = var.physical_module_inputs.monitoring_interval
+    monitoring_role_arn       = var.physical_module_inputs.monitoring_role_arn
     publicly_accessible       = false
     skip_final_snapshot       = var.physical_module_inputs.skip_final_snapshot
     source_security_group_ids = var.physical_module_inputs.source_security_group_ids

--- a/modules/native-db/outputs.tf
+++ b/modules/native-db/outputs.tf
@@ -1,0 +1,4 @@
+output "ecs_env_vars" {
+  value       = local.ecs_env_vars
+  description = "Environment variables for the Superblocks Agent ECS container. Pass as superblocks_agent_environment_variables in the terraform_aws_superblocks root module."
+}

--- a/modules/native-db/outputs.tf
+++ b/modules/native-db/outputs.tf
@@ -2,3 +2,8 @@ output "ecs_env_vars" {
   value       = local.ecs_env_vars
   description = "Environment variables for the Superblocks Agent ECS container. Pass as superblocks_agent_environment_variables in the terraform_aws_superblocks root module."
 }
+
+output "superblocks_agent_tags" {
+  value       = local.superblocks_agent_tags
+  description = "Agent tags advertising the profiles this OPA serves. Pass as superblocks_agent_tags in the terraform_aws_superblocks root module so the tags the OPA registers cannot drift from the databases it is configured to provision."
+}

--- a/modules/native-db/provider.tf
+++ b/modules/native-db/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/modules/native-db/tests/physical_module.tftest.hcl
+++ b/modules/native-db/tests/physical_module.tftest.hcl
@@ -242,3 +242,70 @@ run "enhanced_monitoring_without_a_role_is_rejected_here_not_inside_the_worker" 
 
   expect_failures = [var.physical_module_inputs]
 }
+
+run "allocated_storage_must_be_positive" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      allocated_storage   = 0
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "subnet_ids_need_at_least_two_availability_zones" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "vpc_id_must_look_like_a_vpc_id" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "not-a-vpc-id"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+# Agent names land in IAM role names and the worker's pool identity. Restrict
+# to lowercase alphanumeric so later resources that reject hyphens/underscores
+# do not force a rename after databases exist.
+run "agent_name_rejects_hyphens" {
+  command = plan
+
+  variables {
+    agent_name = "opa-1"
+  }
+
+  expect_failures = [var.agent_name]
+}
+
+run "agent_name_rejects_underscores" {
+  command = plan
+
+  variables {
+    agent_name = "opa_1"
+  }
+
+  expect_failures = [var.agent_name]
+}

--- a/modules/native-db/tests/physical_module.tftest.hcl
+++ b/modules/native-db/tests/physical_module.tftest.hcl
@@ -309,3 +309,36 @@ run "agent_name_rejects_underscores" {
 
   expect_failures = [var.agent_name]
 }
+
+run "multi_az_alone_cannot_select_rds" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      multi_az            = true
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "deployment_and_multi_az_cannot_be_combined" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {
+        serverless_v2 = {}
+      }
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      multi_az            = true
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}

--- a/modules/native-db/tests/physical_module.tftest.hcl
+++ b/modules/native-db/tests/physical_module.tftest.hcl
@@ -1,0 +1,201 @@
+# Which physical database a caller gets, and which capacity arguments reach it.
+# Aurora Serverless v2 is what a caller gets without asking; Aurora provisioned
+# and standalone RDS are opt-in. Each physical module rejects the other's
+# capacity arguments, so a mode must never forward the other mode's inputs.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+}
+
+variables {
+  agent_name         = "opa1"
+  agent_tags         = ["nonprod", "production"]
+  connector_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-opa1-connector"
+  key_prefix         = "native-db/opa1"
+  region             = "us-east-1"
+  state_bucket_name  = "sb-native-db-us-east-1-123456789012"
+
+  physical_module_inputs = {
+    subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    vpc_id     = "vpc-0123456789abcdef0"
+  }
+}
+
+run "a_caller_that_names_no_capacity_gets_aurora_serverless" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-aurora-managed-cluster"
+    error_message = "The default physical module must be the Aurora cluster, not standalone RDS."
+  }
+
+  assert {
+    condition = can(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.deployment.serverless_v2)
+    error_message = "An omitted deployment must still ask Aurora for Serverless v2 capacity."
+  }
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs), "allocated_storage")
+    error_message = "Aurora has no allocated_storage variable; forwarding it fails the plan with Unsupported argument."
+  }
+
+  assert {
+    condition = [
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
+    ][0] == "./modules/postgres-managed-database,./modules/aws-aurora-managed-cluster"
+    error_message = "The module-source allowlist must name the physical module this OPA actually dispatches."
+  }
+}
+
+run "a_caller_can_ask_aurora_for_provisioned_instances" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {
+        provisioned = {
+          instance_class = "db.r6g.xlarge"
+          instance_count = 3
+        }
+      }
+      subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-aurora-managed-cluster"
+    error_message = "Provisioned capacity is an Aurora deployment shape, so it must still select the Aurora module."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.deployment.provisioned.instance_class == "db.r6g.xlarge"
+    error_message = "A provisioned instance class must reach the Aurora module unchanged."
+  }
+}
+
+run "a_caller_can_ask_for_standalone_rds_by_sizing_an_instance" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      allocated_storage = 100
+      instance_class    = "db.t4g.medium"
+      subnet_ids        = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id            = "vpc-0123456789abcdef0"
+    }
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-rds-managed-instance"
+    error_message = "Instance sizing is RDS-only, so it must select the RDS instance module."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.allocated_storage == 100
+    error_message = "Allocated storage must reach the RDS module unchanged."
+  }
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs), "deployment")
+    error_message = "RDS has no deployment variable; forwarding it fails the plan with Unsupported argument."
+  }
+
+  assert {
+    condition = [
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
+    ][0] == "./modules/postgres-managed-database,./modules/aws-rds-managed-instance"
+    error_message = "The module-source allowlist must follow the selected physical module."
+  }
+}
+
+run "an_rds_instance_needs_both_sizing_inputs" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      instance_class = "db.t4g.medium"
+      subnet_ids     = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id         = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "aurora_capacity_and_rds_sizing_cannot_be_combined" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      allocated_storage = 100
+      deployment        = { serverless_v2 = { max_acu = 8 } }
+      instance_class    = "db.t4g.medium"
+      subnet_ids        = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id            = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "an_aurora_deployment_names_exactly_one_capacity_shape" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {
+        provisioned   = { instance_class = "db.r6g.large" }
+        serverless_v2 = { max_acu = 8 }
+      }
+      subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "an_empty_aurora_deployment_is_rejected_rather_than_silently_defaulted" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {}
+      subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}

--- a/modules/native-db/tests/physical_module.tftest.hcl
+++ b/modules/native-db/tests/physical_module.tftest.hcl
@@ -20,8 +20,9 @@ variables {
   state_bucket_name  = "sb-native-db-us-east-1-123456789012"
 
   physical_module_inputs = {
-    subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
-    vpc_id     = "vpc-0123456789abcdef0"
+    monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    vpc_id              = "vpc-0123456789abcdef0"
   }
 }
 
@@ -72,8 +73,9 @@ run "a_caller_can_ask_aurora_for_provisioned_instances" {
           instance_count = 3
         }
       }
-      subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id     = "vpc-0123456789abcdef0"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
     }
   }
 
@@ -99,10 +101,11 @@ run "a_caller_can_ask_for_standalone_rds_by_sizing_an_instance" {
 
   variables {
     physical_module_inputs = {
-      allocated_storage = 100
-      instance_class    = "db.t4g.medium"
-      subnet_ids        = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id            = "vpc-0123456789abcdef0"
+      allocated_storage   = 100
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
     }
   }
 
@@ -144,9 +147,10 @@ run "an_rds_instance_needs_both_sizing_inputs" {
 
   variables {
     physical_module_inputs = {
-      instance_class = "db.t4g.medium"
-      subnet_ids     = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id         = "vpc-0123456789abcdef0"
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
     }
   }
 
@@ -158,11 +162,12 @@ run "aurora_capacity_and_rds_sizing_cannot_be_combined" {
 
   variables {
     physical_module_inputs = {
-      allocated_storage = 100
-      deployment        = { serverless_v2 = { max_acu = 8 } }
-      instance_class    = "db.t4g.medium"
-      subnet_ids        = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id            = "vpc-0123456789abcdef0"
+      allocated_storage   = 100
+      deployment          = { serverless_v2 = { max_acu = 8 } }
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
     }
   }
 
@@ -178,8 +183,9 @@ run "an_aurora_deployment_names_exactly_one_capacity_shape" {
         provisioned   = { instance_class = "db.r6g.large" }
         serverless_v2 = { max_acu = 8 }
       }
-      subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id     = "vpc-0123456789abcdef0"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
     }
   }
 
@@ -191,7 +197,44 @@ run "an_empty_aurora_deployment_is_rejected_rather_than_silently_defaulted" {
 
   variables {
     physical_module_inputs = {
-      deployment = {}
+      deployment          = {}
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+# Both physical modules default monitoring_interval to 60 and reject that
+# without a role, so the rendered inputs have to carry the pair or no database
+# ever provisions.
+run "enhanced_monitoring_reaches_both_physical_modules" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.monitoring_role_arn == "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    error_message = "The Aurora inputs must carry the Enhanced Monitoring role the caller supplied."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.monitoring_interval == 60
+    error_message = "Enhanced Monitoring must stay on by default rather than relying on the physical module's own default."
+  }
+}
+
+run "enhanced_monitoring_without_a_role_is_rejected_here_not_inside_the_worker" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
       subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
       vpc_id     = "vpc-0123456789abcdef0"
     }

--- a/modules/native-db/tests/runtime_config.tftest.hcl
+++ b/modules/native-db/tests/runtime_config.tftest.hcl
@@ -88,6 +88,20 @@ run "the_worker_owns_its_own_resource_type_allowlist" {
   }
 }
 
+# Match helm/agent databaseLifecycle.pollInterval and the worker's ConfigFromEnv
+# default so Fargate and EKS poll at the same cadence.
+run "poll_interval_matches_helm_and_worker_default" {
+  command = plan
+
+  assert {
+    condition = [
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_POLL_INTERVAL"
+    ][0] == "30s"
+    error_message = "Poll interval must be 30s to match helm/agent databaseLifecycle.pollInterval and the worker default."
+  }
+}
+
 run "the_logical_module_gets_only_the_inputs_it_still_declares" {
   command = plan
 

--- a/modules/native-db/tests/runtime_config.tftest.hcl
+++ b/modules/native-db/tests/runtime_config.tftest.hcl
@@ -1,0 +1,108 @@
+# The runtime configuration this module hands the OPA container. These
+# assertions track contracts the lifecycle worker enforces at startup: a flat
+# lifecycle document, profiles declared only through agent tags, and defaults
+# the worker owns rather than the operator.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+}
+
+variables {
+  agent_name         = "opa1"
+  agent_tags         = ["nonprod", "production"]
+  connector_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-opa1-connector"
+  key_prefix         = "native-db/opa1"
+  region             = "us-east-1"
+  state_bucket_name  = "sb-native-db-us-east-1-123456789012"
+
+  physical_module_inputs = {
+    subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    vpc_id     = "vpc-0123456789abcdef0"
+  }
+}
+
+run "the_lifecycle_document_is_one_flat_configuration" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for key in keys(jsondecode([
+        for env in output.ecs_env_vars : env.value
+        if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+      ][0])) : contains(["engines", "operations"], key)
+    ])
+    error_message = "The worker rejects any key other than engines and operations, including entries and profiles."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).engines == ["postgres"]
+    error_message = "Engines must sit at the document root."
+  }
+
+  assert {
+    condition = alltrue([
+      for operation in ["ensure_database", "ensure_physical_database_instance", "migrate_schema", "retire_database"] :
+      contains(keys(jsondecode([
+        for env in output.ecs_env_vars : env.value
+        if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+      ][0]).operations), operation)
+    ])
+    error_message = "Every operation this OPA serves must sit at the document root."
+  }
+}
+
+run "profiles_are_declared_once_as_agent_tags" {
+  command = plan
+
+  assert {
+    condition     = output.superblocks_agent_tags == "profile:nonprod,profile:production"
+    error_message = "The module must derive the agent tag string so it cannot drift from the lifecycle config."
+  }
+
+  assert {
+    condition = length([
+      for env in output.ecs_env_vars : env.name
+      if env.name == "SUPERBLOCKS_ORCHESTRATOR_AGENT_TAGS"
+    ]) == 0
+    error_message = "The root module already emits SUPERBLOCKS_ORCHESTRATOR_AGENT_TAGS; a second copy would leave the container with two values for one key."
+  }
+}
+
+run "the_worker_owns_its_own_resource_type_allowlist" {
+  command = plan
+
+  assert {
+    condition = length([
+      for env in output.ecs_env_vars : env.name
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES"
+    ]) == 0
+    error_message = "An operator-supplied allowlist replaces the worker default outright, so a hardcoded list breaks the first plan that creates a newly published resource type."
+  }
+}
+
+run "the_logical_module_gets_only_the_inputs_it_still_declares" {
+  command = plan
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform.moduleSelectors.postgres.inputs), "auth_mode")
+    error_message = "The worker sends auth_mode itself; sending it here duplicates a value the module no longer accepts from operators."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform.moduleSelectors.postgres.inputs.connector_role_arn == var.connector_role_arn
+    error_message = "The worker only advertises managed IAM when the logical module inputs carry the connector role it was configured with."
+  }
+}

--- a/modules/native-db/tests/runtime_config.tftest.hcl
+++ b/modules/native-db/tests/runtime_config.tftest.hcl
@@ -20,8 +20,9 @@ variables {
   state_bucket_name  = "sb-native-db-us-east-1-123456789012"
 
   physical_module_inputs = {
-    subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
-    vpc_id     = "vpc-0123456789abcdef0"
+    monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    vpc_id              = "vpc-0123456789abcdef0"
   }
 }
 

--- a/modules/native-db/tests/runtime_config.tftest.hcl
+++ b/modules/native-db/tests/runtime_config.tftest.hcl
@@ -107,3 +107,26 @@ run "the_logical_module_gets_only_the_inputs_it_still_declares" {
     error_message = "The worker only advertises managed IAM when the logical module inputs carry the connector role it was configured with."
   }
 }
+
+# Backend keys partition by profile only. The lifecycle environment axis is
+# gone from the worker contract; keeping {{environment}} here would expand to
+# "unknown" (or a stale literal) and force a state migration later.
+run "backend_keys_partition_by_profile_not_environment" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform.backend.key == "native-db/opa1/logical/{{profile}}/{{resource_key}}.tfstate"
+    error_message = "Logical state must live under <key_prefix>/logical/{{profile}}/{{resource_key}}.tfstate with no environment segment."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.backend.key == "native-db/opa1/physical/{{profile}}/{{resource_key}}.tfstate"
+    error_message = "Physical state must live under <key_prefix>/physical/{{profile}}/{{resource_key}}.tfstate with no environment segment."
+  }
+}

--- a/modules/native-db/tests/runtime_config.tftest.hcl
+++ b/modules/native-db/tests/runtime_config.tftest.hcl
@@ -144,3 +144,57 @@ run "backend_keys_partition_by_profile_not_environment" {
     error_message = "Physical state must live under <key_prefix>/physical/{{profile}}/{{resource_key}}.tfstate with no environment segment."
   }
 }
+
+# The worker's TerraformOperationBackend no longer declares credentialResolver;
+# an emitted field is silently dropped and drifts from the Helm renderer.
+run "terraform_operations_omit_obsolete_credential_resolver" {
+  command = plan
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform), "credentialResolver")
+    error_message = "ensure_database must not emit credentialResolver; the worker no longer declares the field."
+  }
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform), "credentialResolver")
+    error_message = "ensure_physical_database_instance must not emit credentialResolver; the worker no longer declares the field."
+  }
+}
+
+run "pool_max_databases_rejects_fractions" {
+  command = plan
+
+  variables {
+    pool = {
+      max_databases = 1.5
+    }
+  }
+
+  expect_failures = [var.pool]
+}
+
+run "agent_tags_reject_commas" {
+  command = plan
+
+  variables {
+    agent_tags = ["non,prod"]
+  }
+
+  expect_failures = [var.agent_tags]
+}
+
+run "agent_tags_reject_mixed_case" {
+  command = plan
+
+  variables {
+    agent_tags = ["NonProd"]
+  }
+
+  expect_failures = [var.agent_tags]
+}

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -20,7 +20,7 @@ variable "region" {
 
 variable "key_prefix" {
   type        = string
-  description = "Prefix that namespaces this OPA's OpenTofu state within the shared S3 bucket. Must be unique per OPA — using the agent name as a suffix is recommended (e.g. \"native-db/prod\"). Logical database state lands under <key_prefix>/logical/... and physical instance state under <key_prefix>/physical/..."
+  description = "Prefix that namespaces this OPA's OpenTofu state within the shared S3 bucket. Must be unique per OPA — using the agent name as a suffix is recommended (e.g. \"native-db/prod\"). Logical database state lands under <key_prefix>/logical/{{profile}}/... and physical instance state under <key_prefix>/physical/{{profile}}/..."
 
   validation {
     condition     = length(var.key_prefix) > 0 && !startswith(var.key_prefix, "/") && !endswith(var.key_prefix, "/")
@@ -33,8 +33,8 @@ variable "agent_name" {
   description = "Stable name for this OPA deployment (the agents map key from native-db-prereqs, e.g. \"opa1\"). Used as the physical database pool identity. Must be unique within your AWS account and must not change once databases exist."
 
   validation {
-    condition     = can(regex("^[a-z0-9_-]{1,15}$", var.agent_name))
-    error_message = "agent_name must be 1–15 lowercase alphanumeric characters, hyphens, or underscores (matching the agents map key constraint in native-db-prereqs)."
+    condition     = can(regex("^[a-z0-9]{1,15}$", var.agent_name))
+    error_message = "agent_name must be 1–15 lowercase alphanumeric characters (matching the agents map key constraint in native-db-prereqs)."
   }
 }
 

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -48,8 +48,11 @@ variable "agent_tags" {
   }
 
   validation {
-    condition     = !contains(var.agent_tags, "*")
-    error_message = "Wildcard '*' is not permitted in agent_tags. Use explicit profile keys."
+    condition = (
+      alltrue([for t in var.agent_tags : can(regex("^[a-z0-9-]{1,15}$", t))]) &&
+      length(var.agent_tags) == length(toset(var.agent_tags))
+    )
+    error_message = "Each agent_tag must be a unique 1-15 lowercase alphanumeric or hyphen string (matching the agents[].agent_tags constraint in native-db-prereqs). Commas and mixed case break the comma-delimited registration string."
   }
 }
 
@@ -61,7 +64,7 @@ variable "pool" {
   description = "Shared physical pool configuration. max_databases sets the maximum number of logical databases a single RDS instance can hold before a new instance is automatically provisioned. Defaults to 100."
 
   validation {
-    condition     = var.pool.max_databases > 0
+    condition     = var.pool.max_databases > 0 && floor(var.pool.max_databases) == var.pool.max_databases
     error_message = "pool.max_databases must be a positive integer."
   }
 }
@@ -121,6 +124,17 @@ variable "physical_module_inputs" {
       (var.physical_module_inputs.instance_class == null)
     )
     error_message = "physical_module_inputs.allocated_storage and instance_class select standalone RDS and must be set together. Omit both to provision Aurora."
+  }
+
+  validation {
+    condition = (
+      var.physical_module_inputs.multi_az == null ||
+      (
+        var.physical_module_inputs.allocated_storage != null &&
+        var.physical_module_inputs.instance_class != null
+      )
+    )
+    error_message = "physical_module_inputs.multi_az is an RDS-only option and must be set together with allocated_storage and instance_class. Omit multi_az to provision Aurora."
   }
 
   validation {

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -1,0 +1,90 @@
+variable "connector_role_arn" {
+  type        = string
+  description = "ARN of the connector IAM role (from the native-db-prereqs module output agents[<name>].connector_role_arn). Used to authenticate against RDS via IAM at query time."
+}
+
+variable "state_bucket_name" {
+  type        = string
+  description = "Name of the shared S3 state bucket (from the native-db-prereqs module output state_bucket_name). Shared across all OPAs in the same region."
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region where the S3 state bucket and RDS instances live."
+
+  validation {
+    condition     = length(var.region) > 0
+    error_message = "region cannot be empty."
+  }
+}
+
+variable "key_prefix" {
+  type        = string
+  description = "Prefix that namespaces this OPA's OpenTofu state within the shared S3 bucket. Must be unique per OPA — using the agent name as a suffix is recommended (e.g. \"native-db/prod\"). Logical database state lands under <key_prefix>/logical/... and physical instance state under <key_prefix>/physical/..."
+
+  validation {
+    condition     = length(var.key_prefix) > 0 && !startswith(var.key_prefix, "/") && !endswith(var.key_prefix, "/")
+    error_message = "key_prefix must be non-empty and must not start or end with a slash."
+  }
+}
+
+variable "agent_tags" {
+  type        = list(string)
+  description = "Agent profile tags this OPA is registered with (from the native-db-prereqs module output agents[<name>].agent_tags). Used to populate the lifecycle config profiles — must match the agent_tags the OPA advertises to Superblocks. Wildcards are not permitted."
+
+  validation {
+    condition     = length(var.agent_tags) > 0
+    error_message = "agent_tags must contain at least one profile tag."
+  }
+
+  validation {
+    condition     = !contains(var.agent_tags, "*")
+    error_message = "Wildcard '*' is not permitted in agent_tags. Use explicit profile keys."
+  }
+}
+
+variable "pool" {
+  type = object({
+    max_databases = optional(number, 100)
+  })
+  default     = {}
+  description = "Shared physical pool configuration. max_databases sets the maximum number of logical databases a single RDS instance can hold before a new instance is automatically provisioned. Defaults to 100."
+
+  validation {
+    condition     = var.pool.max_databases > 0
+    error_message = "pool.max_databases must be a positive integer."
+  }
+}
+
+variable "physical_module_inputs" {
+  type = object({
+    allocated_storage         = number
+    allowed_cidr_blocks       = optional(list(string), [])
+    backup_retention_period   = optional(number, 7)
+    delete_automated_backups  = optional(bool, true)
+    deletion_protection       = optional(bool, true)
+    instance_class            = string
+    multi_az                  = optional(bool, true)
+    skip_final_snapshot       = optional(bool, false)
+    source_security_group_ids = optional(list(string), [])
+    subnet_ids                = list(string)
+    tags                      = optional(map(string), {})
+    vpc_id                    = string
+  })
+  description = "Physical database configuration applied to every RDS instance this OPA provisions. publicly_accessible is always false and is not configurable — it is enforced by the lifecycle worker IAM policy regardless."
+
+  validation {
+    condition     = var.physical_module_inputs.allocated_storage > 0
+    error_message = "physical_module_inputs.allocated_storage must be a positive integer."
+  }
+
+  validation {
+    condition     = length(var.physical_module_inputs.subnet_ids) >= 2
+    error_message = "physical_module_inputs.subnet_ids must contain at least two subnet IDs (the DB subnet group requires subnets in at least two Availability Zones)."
+  }
+
+  validation {
+    condition     = can(regex("^vpc-[0-9a-f]+$", var.physical_module_inputs.vpc_id))
+    error_message = "physical_module_inputs.vpc_id must be a valid VPC ID (e.g. vpc-0123456789abcdef0)."
+  }
+}

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -86,6 +86,8 @@ variable "physical_module_inputs" {
       }))
     }))
     instance_class            = optional(string)
+    monitoring_interval       = optional(number, 60)
+    monitoring_role_arn       = optional(string)
     multi_az                  = optional(bool)
     skip_final_snapshot       = optional(bool, false)
     source_security_group_ids = optional(list(string), [])
@@ -101,7 +103,17 @@ variable "physical_module_inputs" {
     Standalone RDS is opt-in: set `allocated_storage` and `instance_class` (and optionally `multi_az`) instead of `deployment`. Aurora manages storage and failover itself and accepts none of those three.
 
     publicly_accessible is always false and is not configurable — the lifecycle worker IAM policy enforces it regardless.
+
+    Enhanced Monitoring is on at a 60 second interval, which RDS only accepts alongside an IAM role it can assume. Pass the prerequisite stack's `enhanced_monitoring_role_arn` output as `monitoring_role_arn`, or set `monitoring_interval = 0` to turn Enhanced Monitoring off.
   EOT
+
+  validation {
+    condition = (
+      var.physical_module_inputs.monitoring_interval == 0 ||
+      var.physical_module_inputs.monitoring_role_arn != null
+    )
+    error_message = "physical_module_inputs.monitoring_role_arn is required unless monitoring_interval is 0. Pass the prerequisite stack's enhanced_monitoring_role_arn output, or set monitoring_interval = 0 to disable Enhanced Monitoring."
+  }
 
   validation {
     condition = (

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -68,23 +68,68 @@ variable "pool" {
 
 variable "physical_module_inputs" {
   type = object({
-    allocated_storage         = number
-    allowed_cidr_blocks       = optional(list(string), [])
-    backup_retention_period   = optional(number, 7)
-    delete_automated_backups  = optional(bool, true)
-    deletion_protection       = optional(bool, true)
-    instance_class            = string
-    multi_az                  = optional(bool, true)
+    allocated_storage        = optional(number)
+    allowed_cidr_blocks      = optional(list(string), [])
+    backup_retention_period  = optional(number, 7)
+    delete_automated_backups = optional(bool, false)
+    deletion_protection      = optional(bool, true)
+    deployment = optional(object({
+      provisioned = optional(object({
+        instance_class = optional(string, "db.r6g.large")
+        instance_count = optional(number, 2)
+      }))
+      serverless_v2 = optional(object({
+        auto_pause_seconds = optional(number, 300)
+        instance_count     = optional(number, 1)
+        max_acu            = optional(number, 16)
+        min_acu            = optional(number, 0)
+      }))
+    }))
+    instance_class            = optional(string)
+    multi_az                  = optional(bool)
     skip_final_snapshot       = optional(bool, false)
     source_security_group_ids = optional(list(string), [])
     subnet_ids                = list(string)
     tags                      = optional(map(string), {})
     vpc_id                    = string
   })
-  description = "Physical database configuration applied to every RDS instance this OPA provisions. publicly_accessible is always false and is not configurable — it is enforced by the lifecycle worker IAM policy regardless."
+  description = <<-EOT
+    Physical database configuration applied to every database this OPA provisions.
+
+    Aurora PostgreSQL is the default. Leaving `deployment` unset provisions Aurora Serverless v2, which scales between a floor and ceiling of Aurora Capacity Units with no instance class to pick. Set `deployment.serverless_v2` to choose that range, or `deployment.provisioned` to run fixed instances instead. `min_acu = 0` lets a cluster pause when idle — appropriate for nonprod, not production.
+
+    Standalone RDS is opt-in: set `allocated_storage` and `instance_class` (and optionally `multi_az`) instead of `deployment`. Aurora manages storage and failover itself and accepts none of those three.
+
+    publicly_accessible is always false and is not configurable — the lifecycle worker IAM policy enforces it regardless.
+  EOT
 
   validation {
-    condition     = var.physical_module_inputs.allocated_storage > 0
+    condition = (
+      (var.physical_module_inputs.allocated_storage == null) ==
+      (var.physical_module_inputs.instance_class == null)
+    )
+    error_message = "physical_module_inputs.allocated_storage and instance_class select standalone RDS and must be set together. Omit both to provision Aurora."
+  }
+
+  validation {
+    condition = var.physical_module_inputs.deployment == null || (
+      var.physical_module_inputs.allocated_storage == null &&
+      var.physical_module_inputs.instance_class == null &&
+      var.physical_module_inputs.multi_az == null
+    )
+    error_message = "physical_module_inputs.deployment configures Aurora capacity and cannot be combined with the standalone RDS inputs allocated_storage, instance_class, or multi_az."
+  }
+
+  validation {
+    condition = var.physical_module_inputs.deployment == null || (
+      (var.physical_module_inputs.deployment.provisioned == null ? 0 : 1) +
+      (var.physical_module_inputs.deployment.serverless_v2 == null ? 0 : 1)
+    ) == 1
+    error_message = "physical_module_inputs.deployment must configure exactly one of provisioned or serverless_v2. Omit deployment entirely to accept the Serverless v2 default."
+  }
+
+  validation {
+    condition     = var.physical_module_inputs.allocated_storage == null || try(var.physical_module_inputs.allocated_storage > 0, false)
     error_message = "physical_module_inputs.allocated_storage must be a positive integer."
   }
 

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -28,6 +28,16 @@ variable "key_prefix" {
   }
 }
 
+variable "agent_name" {
+  type        = string
+  description = "Stable name for this OPA deployment (the agents map key from native-db-prereqs, e.g. \"opa1\"). Used as the physical database pool identity. Must be unique within your AWS account and must not change once databases exist."
+
+  validation {
+    condition     = can(regex("^[a-z0-9_-]{1,15}$", var.agent_name))
+    error_message = "agent_name must be 1–15 lowercase alphanumeric characters, hyphens, or underscores (matching the agents map key constraint in native-db-prereqs)."
+  }
+}
+
 variable "agent_tags" {
   type        = list(string)
   description = "Agent profile tags this OPA is registered with (from the native-db-prereqs module output agents[<name>].agent_tags). Used to populate the lifecycle config profiles — must match the agent_tags the OPA advertises to Superblocks. Wildcards are not permitted."


### PR DESCRIPTION
## Summary

An OPA configured with `modules/native-db` today can only provision standalone RDS instances, and the inputs it takes are RDS-shaped: `allocated_storage` and `instance_class` are required. The Native DB setup docs for Fargate already tell customers to write an Aurora Serverless v2 `deployment` block, so a customer following the docs cannot apply this module. This makes Aurora PostgreSQL the default physical database and standalone RDS the opt-in, so the module matches what we publish.

It also brings the rendered runtime config back in line with the contract the lifecycle worker enforces at startup, which moved after the module was written, and fixes a connector-role IAM grant that could never authorize a query.

This supersedes #51 — it carries Hans's `modules/native-db` and `native-db-prereqs` work forward, so it is based on that branch and targets `feat/native-db` directly.

## Context

Aurora is the deployment shape Native DB is built around: one pooled cluster hosts many applications' logical databases, so capacity should scale with load rather than being sized per instance up front. Serverless v2 does that, and `min_acu = 0` lets a nonprod cluster pause when idle. Standalone RDS remains supported for customers who want a fixed instance.

## What changed

`physical_module_inputs` gains an Aurora `deployment` block and makes the RDS sizing inputs optional. Which physical module the worker dispatches is derived from what the caller states rather than from a separate enum: naming instance sizing selects RDS, anything else selects Aurora. Validation keeps the two from being mixed and requires the RDS pair together, so a half-configured instance fails at plan time instead of failing inside the worker.

Aurora Serverless v2, the default, needs no capacity block at all — an omitted `deployment` forwards an empty `serverless_v2` object so the physical module's own defaults govern the ACU range:

```hcl
physical_module_inputs = {
  deployment = {
    serverless_v2 = {
      instance_count = 2
      max_acu        = 32
      min_acu        = 2
    }
  }

  subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
  vpc_id     = "vpc-0123456789abcdef0"
}

# Aurora with fixed instances instead of Serverless v2:
#   deployment = { provisioned = { instance_class = "db.r6g.large", instance_count = 2 } }
#
# Standalone RDS instead of an Aurora cluster: omit deployment and set
#   allocated_storage = 100
#   instance_class    = "db.t4g.medium"
```

Each physical module rejects the other's capacity arguments with `Unsupported argument`, so only the selected mode's inputs are forwarded — Aurora never sees `allocated_storage`, RDS never sees `deployment`, and `SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES` names the logical module plus the one physical module actually in use.

On the worker contract, `SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG` is now the flat single-configuration document the worker parses. It previously wrapped everything in an `entries` list with a `profiles` key, both of which the worker rejects outright:

```json
{
  "engines": ["postgres"],
  "operations": {
    "ensure_database": { "...": "..." },
    "ensure_physical_database_instance": { "...": "..." },
    "migrate_schema": { "backend": "native_runner" },
    "retire_database": { "...": "..." }
  }
}
```

The profiles an OPA serves now have one source of truth. The worker reads them from `SUPERBLOCKS_ORCHESTRATOR_AGENT_TAGS`, which the root module already renders from its own input, so this module exposes the derived string as an output to wire in rather than emitting a second copy of that env var:

```hcl
module "superblocks" {
  # ...
  superblocks_agent_tags                  = module.native_db_opa1.superblocks_agent_tags
  superblocks_agent_environment_variables = module.native_db_opa1.ecs_env_vars
}
```

`SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES` is no longer set. An operator-supplied allowlist replaces the worker's default outright instead of extending it, and the hardcoded list predated Aurora — it had no `aws_rds_cluster` or `aws_rds_cluster_instance`, so every Aurora provision would have been denied. Leaving it unset inherits a default that tracks the modules we ship.

`auth_mode` is gone from the logical module inputs because the worker sends `aws_iam_role` itself and the module no longer takes it from operators. `connector_role_arn` stays: the worker only advertises `managed-IAM-v1` when the logical module inputs carry the connector role it was configured with, and the Helm path derives it into those inputs the same way. That asymmetry is called out in a comment.

`delete_automated_backups` now defaults to `false`, matching both physical modules and the docs — the previous default deleted automated backups when an instance was destroyed.

### Connector role IAM (ENG-5117)

Separately, `native-db-prereqs` granted `rds-db:connect` on the bare data tag, which authorizes nothing. The worker names every database and runtime user from a hashed profile token — the first 16 hex characters of `SHA-256` over the lowercased tag — and enforces that shape when it validates a connection, so the grant could never match a DB user and runtime queries failed with `AccessDenied`:

```diff
-dbuser:cluster-*/sbndb_nonprod_*_runtime
+dbuser:cluster-*/sbndb_6fdc0c6b96ee8a74_*_runtime
```

The token is now derived in the module (`substr(sha256(lower(tag)), 0, 16)`), and a test pins the values published in the setup docs so the two cannot drift. The same stale naming claim is corrected in both examples.

New `*.tftest.hcl` tests cover engine selection, the input validations, the rendered env var and config shape, and the connector grant. They run with `terraform test` / `tofu test` against a mocked AWS provider, no credentials needed.

Linear: ENG-4959, ENG-5117