### PR TITLE
fix(native-db-prereqs): grant ec2:DescribeRouteTables to lifecycle workers

### DIFF
--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -661,6 +661,7 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
             "ec2:DescribeAccountAttributes",
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribeRouteTables",
             "ec2:DescribeSecurityGroupRules",
             "ec2:DescribeSecurityGroups",
             "ec2:DescribeSubnets",

--- a/modules/native-db-prereqs/tests/ec2_provisioning.tftest.hcl
+++ b/modules/native-db-prereqs/tests/ec2_provisioning.tftest.hcl
@@ -1,0 +1,57 @@
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:root"
+      user_id    = "AIDAEXAMPLE"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock-role"
+      id  = "mock-role"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock-policy"
+      id  = "arn:aws:iam::123456789012:policy/mock-policy"
+    }
+  }
+
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      arn = "arn:aws:s3:::sb-native-db-us-east-1-123456789012"
+      id  = "sb-native-db-us-east-1-123456789012"
+    }
+  }
+}
+
+run "grants_the_reads_the_physical_modules_perform" {
+  command = plan
+
+  variables {
+    deployment_type = "eks"
+    region          = "us-east-1"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  # The physical modules declare data.aws_vpc, and reading it resolves the VPC's
+  # main route table. Without this grant the read still succeeds, so provisioning
+  # works, but every plan and apply logs an AccessDenied in the customer account.
+  assert {
+    condition = contains(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning["opa1"].policy).Statement :
+      statement.Action if statement.Sid == "Ec2VpcDescribe"
+    ]), "ec2:DescribeRouteTables")
+    error_message = "Reading data.aws_vpc calls ec2:DescribeRouteTables, so the worker must be granted it."
+  }
+}

--- a/modules/native-db-prereqs/tests/ec2_provisioning.tftest.hcl
+++ b/modules/native-db-prereqs/tests/ec2_provisioning.tftest.hcl
@@ -29,7 +29,7 @@ mock_provider "aws" {
   }
 }
 
-run "grants_the_reads_the_physical_modules_perform" {
+run "ec2_vpc_describe_grants_required_reads" {
   command = plan
 
   variables {
@@ -44,14 +44,26 @@ run "grants_the_reads_the_physical_modules_perform" {
     }
   }
 
-  # The physical modules declare data.aws_vpc, and reading it resolves the VPC's
-  # main route table. Without this grant the read still succeeds, so provisioning
-  # works, but every plan and apply logs an AccessDenied in the customer account.
+  # Pins the full Ec2VpcDescribe allowlist. DescribeRouteTables is easy to drop
+  # in a "remove unused IAM" cleanup — nothing in this module calls it — but
+  # reading data.aws_vpc in the physical modules resolves the VPC's main route
+  # table, and without the grant every plan/apply logs AccessDenied.
   assert {
-    condition = contains(one([
+    condition = toset(one([
       for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning["opa1"].policy).Statement :
       statement.Action if statement.Sid == "Ec2VpcDescribe"
-    ]), "ec2:DescribeRouteTables")
-    error_message = "Reading data.aws_vpc calls ec2:DescribeRouteTables, so the worker must be granted it."
+    ])) == toset([
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeRouteTables",
+      "ec2:DescribeSecurityGroupRules",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVpcAttribute",
+      "ec2:DescribeVpcs",
+    ])
+    error_message = "Ec2VpcDescribe must grant every EC2 describe the physical modules (and data.aws_vpc) perform."
   }
 }


### PR DESCRIPTION
## Summary

The lifecycle worker policy already grants the EC2 describes the physical database modules need, except the one the AWS provider issues on its own: `ec2:DescribeRouteTables`. Provisioning still succeeds without it, which is why this never showed up as a failure. What the customer sees instead is an `AccessDenied` in their CloudTrail on every plan and every apply the worker runs, against a role we told them to trust. That is the kind of finding that trips security tooling and comes back as a support question, so it is worth closing even though nothing is broken.

## Context

This turned up while validating the observability IAM grants (#52) against a real Fargate deployment in the sandbox account. Alongside the `iam:PassRole` denial that work was chasing, CloudTrail logged a second, quieter denial on each run:

```json
{
  "eventName": "DescribeRouteTables",
  "errorCode": "Client.UnauthorizedOperation",
  "userAgent": "APN/1.0 HashiCorp/1.0 Terraform/1.11.11 terraform-provider-aws",
  "requestParameters": {
    "filterSet": { "items": [
      { "name": "association.main", "valueSet": { "items": [{ "value": "true" }] } },
      { "name": "vpc-id", "valueSet": { "items": [{ "value": "vpc-0123456789abcdef0" }] } }
    ] }
  }
}
```

The `association.main` filter identifies the caller: both physical modules declare a VPC data source, and reading it makes the provider resolve that VPC's main route table so it can populate `main_route_table_id`.

```hcl
# terraform-superblocks-databases, in aws-rds-managed-instance and aws-aurora-managed-cluster
data "aws_vpc" "default" {
  id = var.vpc_id
}
```

The provider treats that lookup as best-effort and logs a warning when it fails, so the data source still resolves and the database still comes up. The denial is the only trace.

## What changed

One read-only action joins the `Ec2VpcDescribe` statement, next to the describes that are already there. The statement stays `Resource = "*"` because EC2 describes do not support resource-level permissions — the same scoping the sibling describes already use.

```hcl
Sid    = "Ec2VpcDescribe"
Effect = "Allow"
Action = [
  "ec2:DescribeAccountAttributes",
  "ec2:DescribeAvailabilityZones",
  "ec2:DescribeNetworkInterfaces",
  "ec2:DescribeRouteTables",
  "ec2:DescribeSecurityGroupRules",
  "ec2:DescribeSecurityGroups",
  "ec2:DescribeSubnets",
  "ec2:DescribeTags",
  "ec2:DescribeVpcAttribute",
  "ec2:DescribeVpcs",
]
Resource = "*"
```

A `tofu test` pins the full Action list, not just the new grant. `DescribeRouteTables` is easy to drop in a "remove unused IAM" cleanup — nothing in this module calls it — so the contract has to carry the whole allowlist and the reason for the silent one.

```hcl
assert {
  condition = toset(one([
    for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning["opa1"].policy).Statement :
    statement.Action if statement.Sid == "Ec2VpcDescribe"
  ])) == toset([
    "ec2:DescribeAccountAttributes",
    # ...
    "ec2:DescribeRouteTables",
    # ...
    "ec2:DescribeVpcs",
  ])
  error_message = "Ec2VpcDescribe must grant every EC2 describe the physical modules (and data.aws_vpc) perform."
}
```

---

_Branch, test, and description authored by an AI agent (Cursor) on Wylie's behalf._

Made with [Cursor](https://cursor.com)