### PR TITLE
feat(native-db): merge stack of changes

### DIFF
--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -1,0 +1,83 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Bootstrap the IAM roles and S3 state bucket required before the OPA lifecycle
+# worker can provision RDS/Aurora instances. Run this once per region.
+# EKS customers only need this module — runtime config goes in the Helm chart.
+#
+# Registry path (when consuming from Terraform Registry):
+#   source  = "superblocksteam/superblocks/aws//modules/native-db-prereqs"
+#   version = "~>1.0"
+module "native_db_prereqs" {
+  source = "../../modules/native-db-prereqs"
+
+  deployment_type = "eks"
+  region          = "us-east-1"
+
+  # One entry per OPA deployment. The map key is the agent name — used to name
+  # IAM roles and must be unique per AWS account (max 15 characters).
+  agents = {
+    opa1 = {
+      # Agent tags namespace the DB users provisioned by this OPA.
+      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Must match the superblocks_agent_tags configured for this OPA.
+      agent_tags = ["nonprod", "production"]
+
+      # VPC the lifecycle worker is allowed to provision RDS/Aurora into.
+      vpc_id = "vpc-0123456789abcdef0"
+
+      # ARN of the EKS cluster's OIDC provider. Found in the EKS console under
+      # "Configuration > Authentication", or via:
+      #   aws eks describe-cluster --name <cluster-name> \
+      #     --query "cluster.identity.oidc.issuer" --output text
+      oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+
+      # Optional: Kubernetes namespace and service account name of the OPA pod.
+      # Used to scope the OIDC trust policy condition to the specific service account
+      # (system:serviceaccount:<namespace>:<service_account_name>). Defaults match
+      # the standard Superblocks Helm chart values — only override if you deviate.
+      # namespace            = "superblocks"
+      # service_account_name = "superblocks-agent"
+
+      # Optional: name of an existing IRSA role to attach lifecycle worker policies
+      # to. When omitted, the module creates a new role. Use this when your OPA pod
+      # already has an IRSA-annotated role from a prior Helm install (brownfield).
+      # The existing role's trust policy is left unchanged.
+      # existing_role_name = "my-existing-opa-irsa-role"
+
+      # Optional: ARN of a customer-managed KMS key used to encrypt the RDS-managed
+      # master secret in Secrets Manager. When omitted, the secret uses the AWS-managed
+      # Secrets Manager key for your account.
+      # rds_secret_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+    }
+
+    # Example: second OPA in the same region, different EKS cluster.
+    # opa2 = {
+    #   agent_tags        = ["staging"]
+    #   vpc_id            = "vpc-0fedcba9876543210"
+    #   oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE0987654321"
+    # }
+  }
+
+  # Optional: override the default resource name prefix ("sb-native-db").
+  # name_prefix = "acme-native-db"
+
+  # Optional: customer-managed KMS key for the OpenTofu state bucket.
+  # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+
+  # Optional: additional tags applied to all resources created by this module.
+  tags = {
+    Environment = "production"
+  }
+}
+
+output "agents" {
+  value       = module.native_db_prereqs.agents
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (annotate the OPA service account via eks.amazonaws.com/role-arn) and connector_role_arn (pass to OPA Helm chart as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "state_bucket_name" {
+  value       = module.native_db_prereqs.state_bucket_name
+  description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}

--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -66,15 +66,37 @@ module "native_db_prereqs" {
   # Optional: customer-managed KMS key for the OpenTofu state bucket.
   # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
 
+  # Optional: reuse an account-level Enhanced Monitoring role created by a
+  # prior regional apply of this module. The role name is account-scoped
+  # (<name_prefix>-enhanced-monitoring), so a second region must pass the ARN
+  # from the first instead of creating another copy.
+  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+
   # Optional: additional tags applied to all resources created by this module.
   tags = {
     Environment = "production"
   }
 }
 
+# Wire enhanced_monitoring_role_arn into the OPA Helm chart so physical
+# modules can attach Enhanced Monitoring (default monitoring_interval is 60).
+# Without this, plans fail the module precondition even though the IAM role
+# exists:
+#
+#   databaseLifecycle:
+#     physicalModuleInputs:
+#       monitoring_role_arn: <module.native_db_prereqs.enhanced_monitoring_role_arn>
+#
+# Or opt out with monitoring_interval: 0.
+
 output "agents" {
   value       = module.native_db_prereqs.agents
   description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (annotate the OPA service account via eks.amazonaws.com/role-arn) and connector_role_arn (pass to OPA Helm chart as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "enhanced_monitoring_role_arn" {
+  value       = module.native_db_prereqs.enhanced_monitoring_role_arn
+  description = "Pass to OPA Helm as databaseLifecycle.physicalModuleInputs.monitoring_role_arn so Enhanced Monitoring can attach. Required unless you set monitoring_interval: 0."
 }
 
 output "state_bucket_name" {

--- a/examples/native-db-eks/main.tf
+++ b/examples/native-db-eks/main.tf
@@ -19,8 +19,10 @@ module "native_db_prereqs" {
   # IAM roles and must be unique per AWS account (max 15 characters).
   agents = {
     opa1 = {
-      # Agent tags namespace the DB users provisioned by this OPA.
-      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Agent tags namespace the DB users provisioned by this OPA. Each tag is
+      # hashed into a profile token — the first 16 hex characters of SHA-256 over
+      # the lowercased tag — so "nonprod" creates runtime users as
+      # sbndb_6fdc0c6b96ee8a74_<application-token>_runtime.
       # Must match the superblocks_agent_tags configured for this OPA.
       agent_tags = ["nonprod", "production"]
 

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -1,0 +1,73 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Step 1 of 2 for Fargate customers: bootstrap IAM roles and S3 state bucket.
+# Pass the outputs of this module into modules/native-db (step 2), which
+# generates the ecs_env_vars wired into the OPA ECS task definition.
+#
+# Registry path (when consuming from Terraform Registry):
+#   source  = "superblocksteam/superblocks/aws//modules/native-db-prereqs"
+#   version = "~>1.0"
+module "native_db_prereqs" {
+  source = "../../modules/native-db-prereqs"
+
+  deployment_type = "fargate"
+  region          = "us-east-1"
+
+  # One entry per OPA deployment. The map key is the agent name — used to name
+  # IAM roles and must be unique per AWS account (max 15 characters).
+  agents = {
+    opa1 = {
+      # Agent tags namespace the DB users provisioned by this OPA.
+      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Must match the superblocks_agent_tags configured for this OPA.
+      agent_tags = ["nonprod", "production"]
+
+      # VPC the lifecycle worker is allowed to provision RDS/Aurora into.
+      vpc_id = "vpc-0123456789abcdef0"
+
+      # Optional: name of an existing ECS task IAM role to attach lifecycle worker
+      # policies to. When omitted, the module creates a new role. Use this when
+      # your OPA ECS task already has a role you want to reuse (brownfield).
+      # existing_role_name = "my-existing-opa-task-role"
+
+      # Optional: ARN of a customer-managed KMS key used to encrypt the RDS-managed
+      # master secret in Secrets Manager. When omitted, the secret uses the AWS-managed
+      # Secrets Manager key for your account.
+      # rds_secret_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+    }
+
+    # Example: second OPA in the same region. No state_bucket_name wiring needed —
+    # all agents in this module invocation share the same S3 bucket automatically.
+    # opa2 = {
+    #   agent_tags = ["staging"]
+    #   vpc_id     = "vpc-0fedcba9876543210"
+    # }
+  }
+
+  # Optional: override the default resource name prefix ("sb-native-db").
+  # IAM roles are named <name_prefix>-<agent_name>-*; the S3 state bucket is
+  # named <name_prefix>-<region>-<account_id>.
+  # Max 16 characters. Only needed when your org enforces a naming convention.
+  # name_prefix = "acme-native-db"
+
+  # Optional: customer-managed KMS key for the OpenTofu state bucket.
+  # When omitted, the bucket uses AWS account-default encryption (SSE-S3).
+  # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
+
+  # Optional: additional tags applied to all resources created by this module.
+  tags = {
+    Environment = "production"
+  }
+}
+
+output "agents" {
+  value       = module.native_db_prereqs.agents
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (set as ECS task role ARN) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "state_bucket_name" {
+  value       = module.native_db_prereqs.state_bucket_name
+  description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -56,15 +56,31 @@ module "native_db_prereqs" {
   # When omitted, the bucket uses AWS account-default encryption (SSE-S3).
   # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
 
+  # Optional: reuse an account-level Enhanced Monitoring role created by a
+  # prior regional apply of this module. The role name is account-scoped
+  # (<name_prefix>-enhanced-monitoring), so a second region must pass the ARN
+  # from the first instead of creating another copy.
+  # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+
   # Optional: additional tags applied to all resources created by this module.
   tags = {
     Environment = "production"
   }
 }
 
+# Pass enhanced_monitoring_role_arn into modules/native-db (step 2) as
+# physical_module_inputs.monitoring_role_arn. Physical modules default
+# monitoring_interval to 60 and reject plans when the role ARN is missing.
+# Opt out with monitoring_interval = 0.
+
 output "agents" {
   value       = module.native_db_prereqs.agents
   description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (set as ECS task role ARN) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "enhanced_monitoring_role_arn" {
+  value       = module.native_db_prereqs.enhanced_monitoring_role_arn
+  description = "Pass into modules/native-db (or physicalModuleInputs.monitoring_role_arn) so Enhanced Monitoring can attach. Required unless you set monitoring_interval = 0."
 }
 
 output "state_bucket_name" {

--- a/examples/native-db-fargate/main.tf
+++ b/examples/native-db-fargate/main.tf
@@ -19,8 +19,10 @@ module "native_db_prereqs" {
   # IAM roles and must be unique per AWS account (max 15 characters).
   agents = {
     opa1 = {
-      # Agent tags namespace the DB users provisioned by this OPA.
-      # A tag "nonprod" creates runtime users as sbndb_nonprod_<db-id>_runtime.
+      # Agent tags namespace the DB users provisioned by this OPA. Each tag is
+      # hashed into a profile token — the first 16 hex characters of SHA-256 over
+      # the lowercased tag — so "nonprod" creates runtime users as
+      # sbndb_6fdc0c6b96ee8a74_<application-token>_runtime.
       # Must match the superblocks_agent_tags configured for this OPA.
       agent_tags = ["nonprod", "production"]
 
@@ -68,14 +70,89 @@ module "native_db_prereqs" {
   }
 }
 
-# Pass enhanced_monitoring_role_arn into modules/native-db (step 2) as
-# physical_module_inputs.monitoring_role_arn. Physical modules default
-# monitoring_interval to 60 and reject plans when the role ARN is missing.
-# Opt out with monitoring_interval = 0.
+# Step 2 of 2: generate the runtime configuration the OPA ECS container needs to
+# run the lifecycle worker. Call this once per OPA. In the
+# terraform-aws-superblocks root module that manages the ECS task definition,
+# pass ecs_env_vars as superblocks_agent_environment_variables and
+# superblocks_agent_tags as superblocks_agent_tags — the worker reads the
+# profiles it serves from those tags, so taking them from this module keeps them
+# from drifting away from the databases it is configured to provision.
+#
+# Registry path (when consuming from Terraform Registry):
+#   source  = "superblocksteam/superblocks/aws//modules/native-db"
+#   version = "~>1.0"
+module "native_db_opa1" {
+  source = "../../modules/native-db"
+
+  # Wired directly from native-db-prereqs outputs.
+  agent_name         = "opa1"
+  connector_role_arn = module.native_db_prereqs.agents["opa1"].connector_role_arn
+  agent_tags         = module.native_db_prereqs.agents["opa1"].agent_tags
+  state_bucket_name  = module.native_db_prereqs.state_bucket_name
+
+  region = "us-east-1"
+
+  # Namespaces this OPA's OpenTofu state within the shared S3 bucket.
+  # Must be unique per OPA. Using the agent name as a suffix is recommended.
+  key_prefix = "native-db/opa1"
+
+  physical_module_inputs = {
+    # Aurora Serverless v2 is the default: capacity scales between min_acu and
+    # max_acu with no instance class to size. Omit `deployment` entirely to
+    # accept the module defaults, or state the range you want. instance_count
+    # = 2 keeps a second warm instance for immediate failover.
+    #
+    # min_acu = 0 lets a cluster pause when idle. Use it for nonprod, not
+    # production.
+    deployment = {
+      serverless_v2 = {
+        instance_count = 2
+        max_acu        = 32
+        min_acu        = 2
+      }
+    }
+
+    # Aurora with fixed instances instead of Serverless v2:
+    # deployment = {
+    #   provisioned = {
+    #     instance_class = "db.r6g.large"
+    #     instance_count = 2
+    #   }
+    # }
+
+    # Standalone RDS instead of an Aurora cluster (omit deployment above):
+    # allocated_storage = 100
+    # instance_class    = "db.t4g.medium"
+
+    vpc_id = "vpc-0123456789abcdef0"
+
+    # Subnets in at least two Availability Zones — required by the DB subnet group.
+    subnet_ids = [
+      "subnet-0000000000000001",
+      "subnet-0000000000000002",
+    ]
+
+    # Propagate the same tags applied to IAM and S3 resources above.
+    tags = module.native_db_prereqs.tags
+
+    # Enhanced Monitoring runs at 60 seconds by default, and RDS only accepts
+    # that alongside a role it can assume. Pass the prerequisite stack's role,
+    # or set monitoring_interval = 0 to turn Enhanced Monitoring off.
+    monitoring_role_arn = module.native_db_prereqs.enhanced_monitoring_role_arn
+
+    # Optional: restrict which security groups (e.g. your OPA task SG) can reach
+    # the database over port 5432.
+    # source_security_group_ids = ["sg-0123456789abcdef0"]
+  }
+
+  # Optional: override the pool capacity. Default is 100 logical databases per
+  # Aurora cluster before a new cluster is automatically provisioned.
+  # pool = { max_databases = 50 }
+}
 
 output "agents" {
   value       = module.native_db_prereqs.agents
-  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (set as ECS task role ARN) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+  description = "Per-agent outputs: lifecycle_worker_role_arn (set as the ECS task role ARN), connector_role_arn, and agent_tags."
 }
 
 output "enhanced_monitoring_role_arn" {
@@ -86,4 +163,14 @@ output "enhanced_monitoring_role_arn" {
 output "state_bucket_name" {
   value       = module.native_db_prereqs.state_bucket_name
   description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}
+
+output "opa1_ecs_env_vars" {
+  value       = module.native_db_opa1.ecs_env_vars
+  description = "Pass as superblocks_agent_environment_variables in the terraform-aws-superblocks root module for the opa1 ECS task definition."
+}
+
+output "opa1_superblocks_agent_tags" {
+  value       = module.native_db_opa1.superblocks_agent_tags
+  description = "Pass as superblocks_agent_tags in the terraform-aws-superblocks root module for the opa1 ECS task definition."
 }

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -27,6 +27,21 @@ locals {
   }
 
   # ----------------------------------------------------------------
+  # Profile tokens.
+  #
+  # Every database and runtime user the lifecycle worker creates is named
+  # sbndb_<profile_token>_<application_token>[_runtime], where profile_token is
+  # the first 16 hex characters of SHA-256 over the lowercased data tag. IAM
+  # grants must be written against that token, not the tag itself.
+  #
+  #   printf '%s' nonprod | shasum -a 256 | cut -c1-16  =>  6fdc0c6b96ee8a74
+  # ----------------------------------------------------------------
+  profile_tokens = {
+    for tag in distinct(flatten([for agent in values(var.agents) : agent.agent_tags])) :
+    tag => substr(sha256(lower(tag)), 0, 16)
+  }
+
+  # ----------------------------------------------------------------
   # Tagging
   # ----------------------------------------------------------------
   managed_by_tag = "superblocks-native-database-lifecycle"
@@ -1008,8 +1023,11 @@ resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
 # Assumed at query time by the OPA serving code to generate an RDS IAM
 # authentication token. Trusts only that agent's lifecycle worker role(s).
 #
-# Policy contains one rds-db:connect statement per profile, scoping
-# access to DB users in the sbndb_{profile}_*_runtime namespace.
+# Policy contains one rds-db:connect statement per data tag, scoping access to
+# DB users in the sbndb_{profile_token}_*_runtime namespace. The lifecycle
+# worker derives that token from the tag rather than using the tag itself, so a
+# grant written against the bare tag matches no DB user and every query fails
+# with AccessDenied.
 #
 # Role name format: superblocks-native-db-connector-{agent_name}
 # "superblocks-native-db-connector" is a reserved prefix: the Superblocks
@@ -1048,8 +1066,8 @@ resource "aws_iam_policy" "connector" {
         Effect = "Allow"
         Action = "rds-db:connect"
         Resource = [
-          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:cluster-*/sbndb_${tag}_*_runtime",
-          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:db-*/sbndb_${tag}_*_runtime",
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:cluster-*/sbndb_${local.profile_tokens[tag]}_*_runtime",
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:db-*/sbndb_${local.profile_tokens[tag]}_*_runtime",
         ]
       }
     ]

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -50,6 +50,31 @@ locals {
     subgrp           = "${local.rds_prefix}:subgrp:sb-*"
   }
 
+  # Log groups the physical modules declare explicitly, named
+  # /aws/rds/{cluster,instance}/<sb-identifier>/<log type>.
+  native_cloudwatch_log_group_arn_patterns = [
+    "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/cluster/sb-*",
+    "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/rds/instance/sb-*",
+  ]
+
+  # Regions are wildcarded because one account-level monitoring role serves
+  # every region the worker provisions into; aws:SourceAccount is what blocks
+  # cross-account use.
+  native_rds_monitoring_source_arn_patterns = [
+    "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:cluster:sb-*",
+    "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:db:sb-*",
+  ]
+
+  # Account-level Enhanced Monitoring role. The physical modules never create
+  # it — callers pass this ARN as monitoring_role_arn. Additional regions can
+  # reuse an existing role via existing_monitoring_role_arn.
+  create_monitoring_role = var.existing_monitoring_role_arn == null
+  monitoring_role_arn = (
+    local.create_monitoring_role
+    ? aws_iam_role.enhanced_monitoring[0].arn
+    : var.existing_monitoring_role_arn
+  )
+
   # ----------------------------------------------------------------
   # S3 state bucket ARN (always created, shared across all agents)
   # ----------------------------------------------------------------
@@ -853,6 +878,128 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_secrets" {
   for_each   = var.agents
   role       = local.agent_role_names[each.key]
   policy_arn = aws_iam_policy.lifecycle_worker_secrets[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: Observability (CloudWatch log groups + Enhanced Monitoring PassRole)
+#
+# The physical modules declare CloudWatch log groups explicitly so retention
+# is managed rather than left unbounded, and they attach the shared
+# monitoring role below. AWS requires whoever enables Enhanced Monitoring to
+# hold iam:PassRole on the role being handed to RDS, so that grant is scoped
+# to the single role and conditioned on the one service allowed to receive it.
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_observability" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-observability-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to manage Native DB CloudWatch log groups and pass the shared Enhanced Monitoring role."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CloudWatchLogGroupsForNativeDatabases"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DeleteLogGroup",
+          "logs:ListTagsForResource",
+          "logs:PutRetentionPolicy",
+          "logs:TagResource",
+          "logs:UntagResource",
+        ]
+        Resource = local.native_cloudwatch_log_group_arn_patterns
+      },
+      # The provider reads aws_cloudwatch_log_group through DescribeLogGroups,
+      # which AWS authorizes only against "*" — an iam:SimulateCustomPolicy run
+      # denies it against every log-group ARN pattern. Listing it beside the
+      # scoped actions above silently loses the permission at refresh time.
+      {
+        Sid      = "DescribeLogGroupsIsNotResourceScopable"
+        Effect   = "Allow"
+        Action   = "logs:DescribeLogGroups"
+        Resource = "*"
+      },
+      # CreateDBInstance passes the monitoring role as rds.amazonaws.com, not as
+      # the monitoring.rds.amazonaws.com principal that assumes it. Conditioning
+      # on the latter denies every physical provision once monitoring_interval
+      # is non-zero: AWS reports "no identity-based policy allows the
+      # iam:PassRole action" even though the statement's resource matches.
+      {
+        Sid      = "PassEnhancedMonitoringRole"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = local.monitoring_role_arn
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "rds.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_observability" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_observability[each.key].arn
+}
+
+####################################################################
+# Enhanced Monitoring IAM Role (one per account, shared by all agents)
+#
+# RDS assumes this role to publish Enhanced Monitoring OS metrics to the
+# RDSOSMetrics log group. The physical modules never create it: the attached
+# AWS-managed policy is identical for every database, so one account-level
+# role is reused by all of them and the worker never needs iam:CreateRole.
+# The ArnLike/SourceAccount pair is confused-deputy protection — without it
+# any RDS database in any account could name this role.
+#
+# IAM role names are account-global, so this name cannot repeat within one
+# account: a second region (or a second install) must pass
+# existing_monitoring_role_arn instead of letting the module create its own,
+# or CreateRole fails with EntityAlreadyExists.
+####################################################################
+resource "aws_iam_role" "enhanced_monitoring" {
+  count = local.create_monitoring_role ? 1 : 0
+
+  name = "${var.name_prefix}-enhanced-monitoring"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowRdsEnhancedMonitoringForLifecycleDatabases"
+        Effect = "Allow"
+        Principal = {
+          Service = "monitoring.rds.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = local.native_rds_monitoring_source_arn_patterns
+          }
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  description = "RDS Enhanced Monitoring role shared by every native-database instance and cluster"
+
+  tags = merge(local.tags, {
+    Purpose = "RDS Enhanced Monitoring for native databases"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
+  count = local.create_monitoring_role ? 1 : 0
+
+  role       = aws_iam_role.enhanced_monitoring[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
 ####################################################################

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -1,0 +1,981 @@
+data "aws_caller_identity" "current" {}
+
+# Look up any existing roles customers provide so we can reference their ARNs.
+data "aws_iam_role" "existing" {
+  for_each = { for k, agent in var.agents : k => agent.existing_role_name if agent.existing_role_name != null }
+  name     = each.value
+}
+
+locals {
+  # ----------------------------------------------------------------
+  # Per-agent role resolution.
+  # When existing_role_name is set, use that role; otherwise use the
+  # role created by this module for that agent.
+  # ----------------------------------------------------------------
+  agent_role_names = {
+    for k, agent in var.agents : k =>
+    agent.existing_role_name != null
+    ? agent.existing_role_name
+    : aws_iam_role.lifecycle_worker[k].name
+  }
+
+  agent_role_arns = {
+    for k, agent in var.agents : k =>
+    agent.existing_role_name != null
+    ? data.aws_iam_role.existing[k].arn
+    : aws_iam_role.lifecycle_worker[k].arn
+  }
+
+  # ----------------------------------------------------------------
+  # Tagging
+  # ----------------------------------------------------------------
+  managed_by_tag = "superblocks-native-database-lifecycle"
+  tags           = merge(var.tags, { ManagedBy = local.managed_by_tag })
+
+  # ----------------------------------------------------------------
+  # RDS and EC2 ARN helpers (region + account scoped, not agent scoped)
+  # ----------------------------------------------------------------
+  rds_prefix = "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}"
+  ec2_prefix = "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}"
+
+  rds_resources = {
+    cluster          = "${local.rds_prefix}:cluster:sb-*"
+    cluster_pg       = "${local.rds_prefix}:cluster-pg:sb-*"
+    cluster_pg_all   = "${local.rds_prefix}:cluster-pg:*"
+    cluster_snapshot = "${local.rds_prefix}:cluster-snapshot:sb-*"
+    db               = "${local.rds_prefix}:db:sb-*"
+    pg_sb            = "${local.rds_prefix}:pg:sb-*"
+    pg_all           = "${local.rds_prefix}:pg:*"
+    snapshot         = "${local.rds_prefix}:snapshot:sb-*"
+    subgrp           = "${local.rds_prefix}:subgrp:sb-*"
+  }
+
+  # ----------------------------------------------------------------
+  # S3 state bucket ARN (always created, shared across all agents)
+  # ----------------------------------------------------------------
+  state_bucket_arn = aws_s3_bucket.tofu_state.arn
+
+  # ----------------------------------------------------------------
+  # KMS statement for the state bucket (module-level, one shared bucket).
+  # When a specific KMS key is provided the Resource is scoped to that key.
+  # When null, Resource is * but access is constrained via CalledVia.
+  # ----------------------------------------------------------------
+  state_bucket_kms_statement = merge(
+    {
+      Sid    = "StateBucketKms"
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncryptFrom",
+        "kms:ReEncryptTo",
+      ]
+      Resource = var.kms_key_arn != null ? var.kms_key_arn : "*"
+    },
+    var.kms_key_arn == null ? {
+      Condition = {
+        "ForAnyValue:StringEquals" = {
+          "aws:CalledVia" = "s3.amazonaws.com"
+        }
+      }
+    } : {}
+  )
+
+  # ----------------------------------------------------------------
+  # Per-agent OIDC provider URLs (EKS only).
+  # ARN format: arn:aws:iam::<account>:oidc-provider/<url>
+  # ----------------------------------------------------------------
+  oidc_provider_urls = {
+    for k, agent in var.agents : k =>
+    var.deployment_type == "eks"
+    ? replace(agent.oidc_provider_arn, "/^arn:aws:iam::[0-9]+:oidc-provider\\//", "")
+    : ""
+  }
+
+  # ----------------------------------------------------------------
+  # Per-agent trust policies for the lifecycle worker role.
+  # EKS uses OIDC web identity; Fargate uses ECS task service principal.
+  # ----------------------------------------------------------------
+  lifecycle_worker_assume_role_policies = {
+    for k, agent in var.agents : k =>
+    var.deployment_type == "eks" ? jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect    = "Allow"
+          Action    = "sts:AssumeRoleWithWebIdentity"
+          Principal = { Federated = agent.oidc_provider_arn }
+          Condition = {
+            StringEquals = {
+              "${local.oidc_provider_urls[k]}:aud" = "sts.amazonaws.com"
+            }
+            StringLike = {
+              "${local.oidc_provider_urls[k]}:sub" = "system:serviceaccount:${agent.namespace}:${agent.service_account_name}"
+            }
+          }
+        }
+      ]
+      }) : jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect    = "Allow"
+          Action    = "sts:AssumeRole"
+          Principal = { Service = "ecs-tasks.amazonaws.com" }
+        }
+      ]
+    })
+  }
+
+  # ----------------------------------------------------------------
+  # Per-agent EC2 VPC statement for CreateSecurityGroup.
+  # ec2:VpcID is a single-value condition key on the vpc/ resource type.
+  # ----------------------------------------------------------------
+  agent_ec2_create_sg_vpc_statements = {
+    for k, agent in var.agents : k => [
+      {
+        Sid      = "Ec2CreateSecurityGroupVpc${replace(agent.vpc_id, "-", "")}"
+        Effect   = "Allow"
+        Action   = ["ec2:CreateSecurityGroup"]
+        Resource = "${local.ec2_prefix}:vpc/${agent.vpc_id}"
+        Condition = {
+          StringEquals = {
+            "ec2:VpcID" = agent.vpc_id
+          }
+        }
+      }
+    ]
+  }
+
+  # ----------------------------------------------------------------
+  # Per-agent KMS statement for RDS-managed master secrets.
+  # When a CMK is provided: Resource is scoped to that key.
+  # When null: Resource is * (AWS-managed key path; ViaService + context still apply).
+  # ----------------------------------------------------------------
+  agent_rds_secret_kms_statements = {
+    for k, agent in var.agents : k => {
+      Sid      = "DecryptRdsManagedSecretKmsKey"
+      Effect   = "Allow"
+      Action   = ["kms:Decrypt", "kms:DescribeKey"]
+      Resource = agent.rds_secret_kms_key_arn != null ? agent.rds_secret_kms_key_arn : "*"
+      Condition = {
+        StringEquals = {
+          "kms:ViaService" = "secretsmanager.${var.region}.amazonaws.com"
+        }
+        StringLike = {
+          "kms:EncryptionContext:SecretARN" = [
+            "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+            "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+          ]
+        }
+      }
+    }
+  }
+}
+
+####################################################################
+# Lifecycle Worker IAM Role (one per agent, greenfield only)
+#
+# Skipped when existing_role_name is set for that agent — policies
+# are attached to the provided roles instead.
+####################################################################
+resource "aws_iam_role" "lifecycle_worker" {
+  for_each = { for k, agent in var.agents : k => agent if agent.existing_role_name == null }
+
+  name               = "${var.name_prefix}-${each.key}-lifecycle-worker-${var.region}"
+  assume_role_policy = local.lifecycle_worker_assume_role_policies[each.key]
+
+  tags = local.tags
+}
+
+# ----------------------------------------------------------------
+# Policy: assume the connector role
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_assume_connector" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-assume-connector"
+  description = "Allows the ${each.key} lifecycle worker to assume its connector role for RDS IAM authentication."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AssumeNativeDatabaseConnector"
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = [aws_iam_role.connector[each.key].arn]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_assume_connector" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_assume_connector[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: OpenTofu S3 state backend (shared bucket, per-agent policy)
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_state_bucket" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-state-bucket-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to read and write OpenTofu state in the shared S3 bucket."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "StateBucketList"
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:GetBucketVersioning",
+          "s3:ListBucket",
+        ]
+        Resource = local.state_bucket_arn
+      },
+      {
+        Sid    = "StateBucketObjectReadWrite"
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+        ]
+        Resource = "${local.state_bucket_arn}/*"
+      },
+      local.state_bucket_kms_statement,
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_state_bucket" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_state_bucket[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: RDS provisioning — describe + create
+#
+# Create actions carry security-enforcing conditions:
+#   - ManageMasterUserPassword: master password stored in Secrets Manager
+#     automatically (no plaintext credentials in state).
+#   - PubliclyAccessible: instances must remain VPC-private.
+#   - ManagedBy + Vpc request tags: resources must be tagged at creation
+#     so subsequent mutating-action conditions can scope to them.
+# StorageEncrypted and DatabaseEngine are enforced via IAM condition keys on
+# create actions where AWS supports them (db* and cluster* resource types).
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-rds-provisioning-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to describe and provision RDS/Aurora instances and clusters."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RdsDescribe"
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeDBClusterParameterGroups",
+          "rds:DescribeDBClusterParameters",
+          "rds:DescribeDBClusterSnapshots",
+          "rds:DescribeDBClusters",
+          "rds:DescribeDBEngineVersions",
+          "rds:DescribeDBInstances",
+          "rds:DescribeDBParameterGroups",
+          "rds:DescribeDBParameters",
+          "rds:DescribeDBSnapshots",
+          "rds:DescribeDBSubnetGroups",
+          "rds:DescribeGlobalClusters",
+          "rds:DescribePendingMaintenanceActions",
+          "rds:ListTagsForResource",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "CreateRdsServiceLinkedRole"
+        Effect   = "Allow"
+        Action   = "iam:CreateServiceLinkedRole"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "iam:AWSServiceName" = "rds.amazonaws.com"
+          }
+        }
+      },
+      {
+        # Standalone RDS (non-Aurora) instance creates. Discriminated from
+        # RdsCreateAuroraClusterInstance by rds:ManageMasterUserPassword = true,
+        # which is absent on Aurora cluster member creates (password is managed
+        # at the cluster level). Engine pinned to postgres; storage encryption
+        # and public access enforced at create time.
+        Sid    = "RdsCreateDbInstance"
+        Effect = "Allow"
+        Action = "rds:CreateDBInstance"
+        Resource = [
+          local.rds_resources.db,
+          local.rds_resources.subgrp,
+          local.rds_resources.pg_all,
+        ]
+        Condition = {
+          Bool = {
+            "rds:ManageMasterUserPassword" = "true"
+            "rds:PubliclyAccessible"       = "false"
+            "rds:StorageEncrypted"         = "true"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "rds:DatabaseEngine"       = "postgres"
+          }
+        }
+      },
+      {
+        Sid    = "RdsCreateAuroraCluster"
+        Effect = "Allow"
+        Action = "rds:CreateDBCluster"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg_all,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          Bool = {
+            "rds:ManageMasterUserPassword" = "true"
+            "rds:StorageEncrypted"         = "true"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "rds:DatabaseEngine"       = "aurora-postgresql"
+          }
+        }
+      },
+      {
+        Sid    = "RdsCreateAuroraClusterInstance"
+        Effect = "Allow"
+        Action = "rds:CreateDBInstance"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.db,
+          local.rds_resources.pg_all,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          Bool = {
+            "rds:PubliclyAccessible" = "false"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "rds:DatabaseEngine"       = "aurora-postgresql"
+          }
+        }
+      },
+      {
+        Sid    = "RdsCreateParameterGroups"
+        Effect = "Allow"
+        Action = [
+          "rds:CreateDBClusterParameterGroup",
+          "rds:CreateDBParameterGroup",
+        ]
+        Resource = [
+          local.rds_resources.cluster_pg,
+          local.rds_resources.pg_sb,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateDbSubnetGroup"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBSubnetGroup"
+        Resource = local.rds_resources.subgrp
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsTagOnCreate"
+        Effect = "Allow"
+        Action = "rds:AddTagsToResource"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsTagNativeSnapshotOnCreate"
+        Effect = "Allow"
+        Action = "rds:AddTagsToResource"
+        Resource = [
+          local.rds_resources.cluster_snapshot,
+          local.rds_resources.snapshot,
+        ]
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsEncryptedStorageKmsViaRds"
+        Effect = "Allow"
+        Action = [
+          "kms:CreateGrant",
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey",
+        ]
+        Resource = "*"
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_provisioning" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_rds_provisioning[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: RDS mutation — modify, delete, snapshots, tag management
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-rds-mutation-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to modify, delete, snapshot, and tag RDS/Aurora resources it owns."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RdsMutate"
+        Effect = "Allow"
+        Action = [
+          "rds:DeleteDBCluster",
+          "rds:DeleteDBClusterParameterGroup",
+          "rds:DeleteDBInstance",
+          "rds:DeleteDBParameterGroup",
+          "rds:DeleteDBSubnetGroup",
+          "rds:ModifyDBCluster",
+          "rds:ModifyDBClusterParameterGroup",
+          "rds:ModifyDBInstance",
+          "rds:ModifyDBParameterGroup",
+          "rds:ModifyDBSubnetGroup",
+          "rds:RebootDBCluster",
+          "rds:RebootDBInstance",
+          "rds:ResetDBClusterParameterGroup",
+          "rds:ResetDBParameterGroup",
+        ]
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.pg_all,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          BoolIfExists = {
+            "rds:ManageMasterUserPassword" = "true"
+          }
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsDeleteAuroraClusterFinalSnapshot"
+        Effect   = "Allow"
+        Action   = "rds:DeleteDBCluster"
+        Resource = local.rds_resources.cluster_snapshot
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateSnapshotFromManagedCluster"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBClusterSnapshot"
+        Resource = local.rds_resources.cluster
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateNativeClusterSnapshot"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBClusterSnapshot"
+        Resource = local.rds_resources.cluster_snapshot
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateSnapshotFromManagedInstance"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBSnapshot"
+        Resource = local.rds_resources.db
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "RdsCreateNativeSnapshot"
+        Effect   = "Allow"
+        Action   = "rds:CreateDBSnapshot"
+        Resource = local.rds_resources.snapshot
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsAddTagsToManagedResources"
+        Effect = "Allow"
+        Action = "rds:AddTagsToResource"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.cluster_snapshot,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.pg_all,
+          local.rds_resources.snapshot,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+          StringEqualsIfExists = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "RdsRemoveTagsExceptScopingTags"
+        Effect = "Allow"
+        Action = "rds:RemoveTagsFromResource"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.cluster_snapshot,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.pg_all,
+          local.rds_resources.snapshot,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+          "ForAllValues:StringNotEquals" = {
+            "aws:TagKeys" = ["ManagedBy", "Vpc"]
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_mutation" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_rds_mutation[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: EC2 networking — VPC describe + security group management
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-ec2-provisioning-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to describe VPCs and manage security groups it created."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Sid    = "Ec2VpcDescribe"
+          Effect = "Allow"
+          Action = [
+            "ec2:DescribeAccountAttributes",
+            "ec2:DescribeAvailabilityZones",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribeSecurityGroupRules",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeTags",
+            "ec2:DescribeVpcAttribute",
+            "ec2:DescribeVpcs",
+          ]
+          Resource = "*"
+        },
+        {
+          Sid      = "Ec2CreateSecurityGroupResource"
+          Effect   = "Allow"
+          Action   = ["ec2:CreateSecurityGroup"]
+          Resource = "${local.ec2_prefix}:security-group/*"
+          Condition = {
+            StringEquals = {
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+            }
+          }
+        },
+        {
+          Sid    = "Ec2SecurityGroupMutate"
+          Effect = "Allow"
+          Action = [
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:DeleteSecurityGroup",
+            "ec2:ModifySecurityGroupRules",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:RevokeSecurityGroupIngress",
+          ]
+          Resource = "*"
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+          }
+        },
+        {
+          Sid    = "Ec2CreateTagsOnCreateSecurityGroup"
+          Effect = "Allow"
+          Action = ["ec2:CreateTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+              "ec2:CreateAction"         = "CreateSecurityGroup"
+            }
+          }
+        },
+        {
+          Sid    = "Ec2CreateTagsOnManagedResources"
+          Effect = "Allow"
+          Action = ["ec2:CreateTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+            StringEqualsIfExists = {
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+            }
+          }
+        },
+        {
+          Sid    = "Ec2DeleteTagsExceptScopingTags"
+          Effect = "Allow"
+          Action = ["ec2:DeleteTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+            "ForAllValues:StringNotEquals" = {
+              "aws:TagKeys" = ["ManagedBy", "Vpc"]
+            }
+          }
+        },
+      ],
+      local.agent_ec2_create_sg_vpc_statements[each.key]
+    )
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_ec2_provisioning" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_ec2_provisioning[each.key].arn
+}
+
+# ----------------------------------------------------------------
+# Policy: Secrets Manager
+# ----------------------------------------------------------------
+resource "aws_iam_policy" "lifecycle_worker_secrets" {
+  for_each = var.agents
+
+  name        = "${var.name_prefix}-${each.key}-secrets-${var.region}"
+  description = "Allows the ${each.key} lifecycle worker to manage RDS master credentials and read RDS-managed secrets."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CreateRdsManagedMasterSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:CreateSecret"
+        Resource = [
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+        ]
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid    = "TagRdsManagedMasterSecretsViaRds"
+        Effect = "Allow"
+        Action = "secretsmanager:TagResource"
+        Resource = [
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+        ]
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+          StringEquals = {
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      {
+        Sid      = "DescribeRdsManagedSecretKmsKeyViaRds"
+        Effect   = "Allow"
+        Action   = "kms:DescribeKey"
+        Resource = "*"
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:CalledVia" = "rds.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "ReadTaggedRdsManagedMasterSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecretValue",
+        ]
+        Resource = [
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-*",
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-*",
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+            "aws:ResourceTag/Vpc"       = each.value.vpc_id
+          }
+        }
+      },
+      local.agent_rds_secret_kms_statements[each.key],
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_worker_secrets" {
+  for_each   = var.agents
+  role       = local.agent_role_names[each.key]
+  policy_arn = aws_iam_policy.lifecycle_worker_secrets[each.key].arn
+}
+
+####################################################################
+# Connector IAM Role (one per agent)
+#
+# Assumed at query time by the OPA serving code to generate an RDS IAM
+# authentication token. Trusts only that agent's lifecycle worker role(s).
+#
+# Policy contains one rds-db:connect statement per profile, scoping
+# access to DB users in the sbndb_{profile}_*_runtime namespace.
+#
+# Role name format: superblocks-native-db-connector-{agent_name}
+# "superblocks-native-db-connector" is a reserved prefix: the Superblocks
+# server rejects customer-provided role names starting with it.
+####################################################################
+resource "aws_iam_role" "connector" {
+  for_each = var.agents
+
+  name = "superblocks-native-db-connector-${each.key}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowOnlyTrustedOpa"
+        Effect    = "Allow"
+        Action    = "sts:AssumeRole"
+        Principal = { AWS = [local.agent_role_arns[each.key]] }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "connector" {
+  for_each = var.agents
+
+  name        = "superblocks-native-db-connector-${each.key}"
+  description = "Allows the ${each.key} connector role to authenticate to RDS/Aurora instances using IAM database authentication."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      for tag in each.value.agent_tags : {
+        Sid    = "ConnectTag${replace(replace(title(tag), "-", ""), "_", "")}"
+        Effect = "Allow"
+        Action = "rds-db:connect"
+        Resource = [
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:cluster-*/sbndb_${tag}_*_runtime",
+          "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:db-*/sbndb_${tag}_*_runtime",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "connector" {
+  for_each   = var.agents
+  role       = aws_iam_role.connector[each.key].name
+  policy_arn = aws_iam_policy.connector[each.key].arn
+}
+
+####################################################################
+# S3 OpenTofu State Bucket
+#
+# Shared across all agents in this module invocation (same account+region).
+# Always created — no conditional logic needed since all agents are declared
+# in this single module call.
+#
+# Bucket name format: <name_prefix>-<region>-<account_id>
+####################################################################
+resource "aws_s3_bucket" "tofu_state" {
+  bucket = "${var.name_prefix}-${var.region}-${data.aws_caller_identity.current.account_id}"
+
+  tags = local.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tofu_state" {
+  bucket = aws_s3_bucket.tofu_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tofu_state" {
+  bucket = aws_s3_bucket.tofu_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tofu_state" {
+  count  = var.kms_key_arn != null ? 1 : 0
+  bucket = aws_s3_bucket.tofu_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = false
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tofu_state" {
+  bucket = aws_s3_bucket.tofu_state.id
+
+  rule {
+    id     = "expire-noncurrent-state-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}

--- a/modules/native-db-prereqs/main.tf
+++ b/modules/native-db-prereqs/main.tf
@@ -661,6 +661,7 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
             "ec2:DescribeAccountAttributes",
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribeRouteTables",
             "ec2:DescribeSecurityGroupRules",
             "ec2:DescribeSecurityGroups",
             "ec2:DescribeSubnets",

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -1,0 +1,14 @@
+output "agents" {
+  value = {
+    for k in keys(var.agents) : k => {
+      lifecycle_worker_role_arn = local.agent_role_arns[k]
+      connector_role_arn        = aws_iam_role.connector[k].arn
+    }
+  }
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role — set as the ECS task role or annotate the EKS service account) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+}
+
+output "state_bucket_name" {
+  value       = aws_s3_bucket.tofu_state.id
+  description = "Name of the S3 bucket used for OpenTofu state, shared across all agents in this module invocation."
+}

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -3,9 +3,10 @@ output "agents" {
     for k in keys(var.agents) : k => {
       lifecycle_worker_role_arn = local.agent_role_arns[k]
       connector_role_arn        = aws_iam_role.connector[k].arn
+      agent_tags                = var.agents[k].agent_tags
     }
   }
-  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role — set as the ECS task role or annotate the EKS service account) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
+  description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role), connector_role_arn (pass as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN), and agent_tags (pass as agent_tags to the native-db module)."
 }
 
 output "enhanced_monitoring_role_arn" {
@@ -16,4 +17,9 @@ output "enhanced_monitoring_role_arn" {
 output "state_bucket_name" {
   value       = aws_s3_bucket.tofu_state.id
   description = "Name of the S3 bucket used for OpenTofu state, shared across all agents in this module invocation."
+}
+
+output "tags" {
+  value       = local.tags
+  description = "Tags applied to all resources created by this module. Pass to the native-db module's physical_module_inputs.tags to tag RDS instances with the same values."
 }

--- a/modules/native-db-prereqs/outputs.tf
+++ b/modules/native-db-prereqs/outputs.tf
@@ -8,6 +8,11 @@ output "agents" {
   description = "Per-agent outputs. For each agent: lifecycle_worker_role_arn (ARN of the lifecycle worker role — set as the ECS task role or annotate the EKS service account) and connector_role_arn (pass to the OPA runtime config as SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN)."
 }
 
+output "enhanced_monitoring_role_arn" {
+  value       = local.monitoring_role_arn
+  description = "ARN of the account-level RDS Enhanced Monitoring role. Pass this to the physical database modules as monitoring_role_arn (for example via databaseLifecycle.physicalModuleInputs); without it they reject monitoring_interval > 0 at plan time."
+}
+
 output "state_bucket_name" {
   value       = aws_s3_bucket.tofu_state.id
   description = "Name of the S3 bucket used for OpenTofu state, shared across all agents in this module invocation."

--- a/modules/native-db-prereqs/provider.tf
+++ b/modules/native-db-prereqs/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/modules/native-db-prereqs/tests/agent_names.tftest.hcl
+++ b/modules/native-db-prereqs/tests/agent_names.tftest.hcl
@@ -1,0 +1,65 @@
+# Agent names (the agents map keys) are embedded in IAM role names. Restrict
+# them to lowercase alphanumeric so a later resource that rejects hyphens or
+# underscores does not force a rename after databases exist.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock"
+    }
+  }
+}
+
+variables {
+  deployment_type = "fargate"
+  region          = "us-east-1"
+
+  agents = {
+    opa1 = {
+      agent_tags = ["nonprod"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+}
+
+run "agent_names_reject_hyphens" {
+  command = plan
+
+  variables {
+    agents = {
+      "opa-1" = {
+        agent_tags = ["nonprod"]
+        vpc_id     = "vpc-0123456789abcdef0"
+      }
+    }
+  }
+
+  expect_failures = [var.agents]
+}
+
+run "agent_names_reject_underscores" {
+  command = plan
+
+  variables {
+    agents = {
+      "opa_1" = {
+        agent_tags = ["nonprod"]
+        vpc_id     = "vpc-0123456789abcdef0"
+      }
+    }
+  }
+
+  expect_failures = [var.agents]
+}

--- a/modules/native-db-prereqs/tests/connector_policy.tftest.hcl
+++ b/modules/native-db-prereqs/tests/connector_policy.tftest.hcl
@@ -1,0 +1,107 @@
+# The connector role's rds-db:connect grant has to name the DB users the
+# lifecycle worker actually creates. The worker derives the profile segment of
+# every database and runtime user from the data tag by hashing it — first 16 hex
+# characters of SHA-256 over the lowercased tag — so a policy written against the
+# bare tag matches nothing and every query fails with AccessDenied.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  # Generated mock IDs are not ARN-shaped, and the provider validates the
+  # policy_arn it is handed before any assertion runs.
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock"
+    }
+  }
+}
+
+variables {
+  deployment_type = "fargate"
+  region          = "us-east-1"
+
+  agents = {
+    prod = {
+      agent_tags = ["nonprod", "production"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+}
+
+run "the_connect_grant_names_hashed_profile_tokens" {
+  command = plan
+
+  # printf '%s' nonprod | shasum -a 256 | cut -c1-16
+  assert {
+    condition = contains(
+      flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]),
+      "arn:aws:rds-db:us-east-1:123456789012:dbuser:cluster-*/sbndb_6fdc0c6b96ee8a74_*_runtime"
+    )
+    error_message = "The Aurora grant for the nonprod tag must name the hashed profile token 6fdc0c6b96ee8a74."
+  }
+
+  assert {
+    condition = contains(
+      flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]),
+      "arn:aws:rds-db:us-east-1:123456789012:dbuser:db-*/sbndb_6fdc0c6b96ee8a74_*_runtime"
+    )
+    error_message = "The standalone RDS grant for the nonprod tag must name the hashed profile token 6fdc0c6b96ee8a74."
+  }
+
+  # printf '%s' production | shasum -a 256 | cut -c1-16
+  assert {
+    condition = contains(
+      flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]),
+      "arn:aws:rds-db:us-east-1:123456789012:dbuser:cluster-*/sbndb_ab8e18ef4ebebedd_*_runtime"
+    )
+    error_message = "The Aurora grant for the production tag must name the hashed profile token ab8e18ef4ebebedd."
+  }
+
+  assert {
+    condition = alltrue([
+      for resource in flatten([for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Resource]) :
+      can(regex("/sbndb_[0-9a-f]{16}_\\*_runtime$", resource))
+    ])
+    error_message = "Every grant must target the sbndb_<16 hex>_<application token>_runtime namespace the worker creates; a bare data tag matches no DB user."
+  }
+
+  # The Sid stays human-readable so an operator can map a statement back to the
+  # tag that produced it — only the DB user namespace is hashed.
+  assert {
+    condition = [
+      for statement in jsondecode(aws_iam_policy.connector["prod"].policy).Statement : statement.Sid
+    ] == ["ConnectTagNonprod", "ConnectTagProduction"]
+    error_message = "Statement Sids must name the data tag they came from."
+  }
+}
+
+run "the_tags_output_matches_what_the_module_stamps" {
+  command = plan
+
+  variables {
+    tags = { Environment = "production" }
+  }
+
+  # The example forwards this output into physical_module_inputs.tags, so it has
+  # to be the merged set the module puts on its own resources, not the caller's
+  # raw input.
+  assert {
+    condition     = tomap(output.tags) == aws_iam_role.lifecycle_worker["prod"].tags
+    error_message = "The tags output must equal the tags the module applies to the resources it creates."
+  }
+
+  assert {
+    condition     = output.tags == { Environment = "production", ManagedBy = "superblocks-native-database-lifecycle" }
+    error_message = "The tags output must merge ManagedBy over the caller's tags."
+  }
+}

--- a/modules/native-db-prereqs/tests/ec2_provisioning.tftest.hcl
+++ b/modules/native-db-prereqs/tests/ec2_provisioning.tftest.hcl
@@ -1,0 +1,69 @@
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:root"
+      user_id    = "AIDAEXAMPLE"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock-role"
+      id  = "mock-role"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock-policy"
+      id  = "arn:aws:iam::123456789012:policy/mock-policy"
+    }
+  }
+
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      arn = "arn:aws:s3:::sb-native-db-us-east-1-123456789012"
+      id  = "sb-native-db-us-east-1-123456789012"
+    }
+  }
+}
+
+run "ec2_vpc_describe_grants_required_reads" {
+  command = plan
+
+  variables {
+    deployment_type = "eks"
+    region          = "us-east-1"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  # Pins the full Ec2VpcDescribe allowlist. DescribeRouteTables is easy to drop
+  # in a "remove unused IAM" cleanup — nothing in this module calls it — but
+  # reading data.aws_vpc in the physical modules resolves the VPC's main route
+  # table, and without the grant every plan/apply logs AccessDenied.
+  assert {
+    condition = toset(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning["opa1"].policy).Statement :
+      statement.Action if statement.Sid == "Ec2VpcDescribe"
+    ])) == toset([
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeRouteTables",
+      "ec2:DescribeSecurityGroupRules",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVpcAttribute",
+      "ec2:DescribeVpcs",
+    ])
+    error_message = "Ec2VpcDescribe must grant every EC2 describe the physical modules (and data.aws_vpc) perform."
+  }
+}

--- a/modules/native-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/native-db-prereqs/tests/observability.tftest.hcl
@@ -1,0 +1,288 @@
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:root"
+      user_id    = "AIDAEXAMPLE"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock-role"
+      id  = "mock-role"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock-policy"
+      id  = "arn:aws:iam::123456789012:policy/mock-policy"
+    }
+  }
+
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      arn = "arn:aws:s3:::sb-native-db-us-east-1-123456789012"
+      id  = "sb-native-db-us-east-1-123456789012"
+    }
+  }
+}
+
+# The mock defaults above give every aws_iam_policy the same arn, which would
+# let a cross-resource assertion (attachment.policy_arn == policy.arn) pass
+# even if the attachment referenced an adjacent policy by mistake. Overriding
+# each address with its own arn makes those assertions load-bearing.
+override_resource {
+  target = aws_iam_role.lifecycle_worker
+  values = { arn = "arn:aws:iam::123456789012:role/mock-lifecycle-worker" }
+}
+
+override_resource {
+  target = aws_iam_role.connector
+  values = { arn = "arn:aws:iam::123456789012:role/mock-connector" }
+}
+
+override_resource {
+  target = aws_iam_role.enhanced_monitoring
+  values = { arn = "arn:aws:iam::123456789012:role/mock-enhanced-monitoring" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_observability
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-observability" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_secrets
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-secrets" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_assume_connector
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-assume-connector" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_state_bucket
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-state-bucket" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_rds_provisioning
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-rds-provisioning" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_rds_mutation
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-rds-mutation" }
+}
+
+override_resource {
+  target = aws_iam_policy.lifecycle_worker_ec2_provisioning
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-ec2-provisioning" }
+}
+
+override_resource {
+  target = aws_iam_policy.connector
+  values = { arn = "arn:aws:iam::123456789012:policy/mock-connector-policy" }
+}
+
+run "grants_native_database_observability_permissions" {
+  command = plan
+
+  variables {
+    deployment_type = "eks"
+    region          = "us-east-1"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for action in [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:ListTagsForResource",
+        "logs:PutRetentionPolicy",
+        "logs:TagResource",
+        "logs:UntagResource",
+      ] :
+      contains(one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "CloudWatchLogGroupsForNativeDatabases"
+      ]), action)
+    ])
+    error_message = "The worker must be able to manage the log groups the physical modules declare explicitly."
+  }
+
+  assert {
+    condition = jsonencode(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      statement.Resource if statement.Sid == "CloudWatchLogGroupsForNativeDatabases"
+      ])) == jsonencode([
+      "arn:aws:logs:us-east-1:123456789012:log-group:/aws/rds/cluster/sb-*",
+      "arn:aws:logs:us-east-1:123456789012:log-group:/aws/rds/instance/sb-*",
+    ])
+    error_message = "CloudWatch Logs grants must stay inside the sb-* namespace the physical modules generate."
+  }
+
+  # Verified with aws iam simulate-custom-policy: DescribeLogGroups evaluates to
+  # implicitDeny against a log-group ARN no matter how the pattern is written,
+  # and to allowed only against "*". Every other action here is resource
+  # scopable, so keeping them in one statement would silently widen them.
+  assert {
+    condition = !contains(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      statement.Action if statement.Sid == "CloudWatchLogGroupsForNativeDatabases"
+    ]), "logs:DescribeLogGroups")
+    error_message = "DescribeLogGroups cannot sit in the sb-* scoped statement: AWS will not authorize it against a log-group ARN, so the provider's read fails with AccessDenied."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "DescribeLogGroupsIsNotResourceScopable"
+      ]) == "logs:DescribeLogGroups" &&
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Resource if statement.Sid == "DescribeLogGroupsIsNotResourceScopable"
+      ]) == "*"
+    )
+    error_message = "The provider reads aws_cloudwatch_log_group through DescribeLogGroups, which only authorizes against \"*\"."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "PassEnhancedMonitoringRole"
+      ]) == "iam:PassRole" &&
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Resource if statement.Sid == "PassEnhancedMonitoringRole"
+      ]) == local.monitoring_role_arn &&
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Condition.StringEquals["iam:PassedToService"] if statement.Sid == "PassEnhancedMonitoringRole"
+      ]) == "rds.amazonaws.com"
+    )
+    error_message = "Enhanced Monitoring attach requires iam:PassRole scoped to the shared monitoring role, conditioned on the service RDS actually passes it as (rds.amazonaws.com, not the monitoring.rds.amazonaws.com principal that assumes it)."
+  }
+
+  assert {
+    condition = (
+      aws_iam_role.enhanced_monitoring[0].name == "sb-native-db-enhanced-monitoring" &&
+      jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Principal.Service == "monitoring.rds.amazonaws.com" &&
+      jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Action == "sts:AssumeRole" &&
+      jsonencode(jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Condition.ArnLike["aws:SourceArn"]) == jsonencode([
+        "arn:aws:rds:*:123456789012:cluster:sb-*",
+        "arn:aws:rds:*:123456789012:db:sb-*",
+      ]) &&
+      jsondecode(aws_iam_role.enhanced_monitoring[0].assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == "123456789012"
+    )
+    error_message = "The shared monitoring role must trust RDS monitoring for sb-* databases in this account only, across every region it provisions into."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.enhanced_monitoring[0].policy_arn == "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+    error_message = "The monitoring role must carry the AWS-managed Enhanced Monitoring policy rather than a hand-written copy."
+  }
+
+  assert {
+    condition = (
+      aws_iam_role_policy_attachment.lifecycle_worker_observability["opa1"].role == local.agent_role_names["opa1"] &&
+      aws_iam_role_policy_attachment.lifecycle_worker_observability["opa1"].policy_arn == aws_iam_policy.lifecycle_worker_observability["opa1"].arn
+    )
+    error_message = "The observability policy must be attached to the lifecycle worker role, not merely declared."
+  }
+
+  assert {
+    condition     = output.enhanced_monitoring_role_arn == local.monitoring_role_arn
+    error_message = "The monitoring role ARN must be exported so operators can pass it as monitoring_role_arn to the physical modules."
+  }
+}
+
+run "reuses_an_existing_monitoring_role" {
+  command = plan
+
+  variables {
+    deployment_type              = "eks"
+    region                       = "us-west-2"
+    existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/platform/sb-native-db-enhanced-monitoring"
+    agents = {
+      opa1 = {
+        agent_tags        = ["staging"]
+        vpc_id            = "vpc-0fedcba9876543210"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/EXAMPLE0987654321"
+      }
+    }
+  }
+
+  assert {
+    condition     = length(aws_iam_role.enhanced_monitoring) == 0
+    error_message = "When existing_monitoring_role_arn is set, the module must not create a second monitoring role."
+  }
+
+  assert {
+    condition = one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      statement.Resource if statement.Sid == "PassEnhancedMonitoringRole"
+    ]) == "arn:aws:iam::123456789012:role/platform/sb-native-db-enhanced-monitoring"
+    error_message = "A worker that reuses an existing monitoring role must be able to pass that role."
+  }
+
+  assert {
+    condition     = output.enhanced_monitoring_role_arn == "arn:aws:iam::123456789012:role/platform/sb-native-db-enhanced-monitoring"
+    error_message = "The monitoring role output must expose the existing role when one is supplied."
+  }
+}
+
+# Every ARN this module builds hardcodes the aws partition, including the
+# AmazonRDSEnhancedMonitoringRole managed-policy ARN and the RDS SourceArn
+# patterns in the trust policy. A GovCloud role would pass an ARN-shape check
+# but never actually be assumable by monitoring.rds.amazonaws.com here, so the
+# validation has to reject it at plan time rather than at provision time.
+run "rejects_a_monitoring_role_outside_the_aws_partition" {
+  command = plan
+
+  variables {
+    deployment_type              = "eks"
+    region                       = "us-gov-west-1"
+    existing_monitoring_role_arn = "arn:aws-us-gov:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-gov-west-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  expect_failures = [var.existing_monitoring_role_arn]
+}
+
+run "rejects_a_malformed_monitoring_role_arn" {
+  command = plan
+
+  variables {
+    deployment_type              = "eks"
+    region                       = "us-east-1"
+    existing_monitoring_role_arn = "sb-native-db-enhanced-monitoring"
+    agents = {
+      opa1 = {
+        agent_tags        = ["nonprod"]
+        vpc_id            = "vpc-0123456789abcdef0"
+        oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE1234567890"
+      }
+    }
+  }
+
+  expect_failures = [var.existing_monitoring_role_arn]
+}

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -73,6 +73,17 @@ variable "kms_key_arn" {
   description = "ARN of the KMS key for the OpenTofu state bucket. When provided, the bucket is configured with SSE-KMS using this key and IAM KMS permissions are scoped to it. When null, the bucket uses the AWS account default encryption and IAM KMS permissions fall back to Resource:* conditioned on aws:CalledVia s3.amazonaws.com."
 }
 
+variable "existing_monitoring_role_arn" {
+  type        = string
+  default     = null
+  description = "ARN of an existing account-level RDS Enhanced Monitoring role. When null, the module creates <name_prefix>-enhanced-monitoring. Set this in additional regions so every worker reuses one shared role instead of creating a second copy. The physical database modules take this ARN as monitoring_role_arn; the worker is granted iam:PassRole on it and nothing else. Setting this on a deployment that previously created the role destroys that role: any database still configured with the old ARN loses Enhanced Monitoring until the physical modules are re-pointed at the role you supply here, so re-point them first."
+
+  validation {
+    condition     = var.existing_monitoring_role_arn == null || can(regex("^arn:aws:iam::[0-9]{12}:role/([A-Za-z0-9+=,.@_-]+/)*[A-Za-z0-9+=,.@_-]+$", var.existing_monitoring_role_arn))
+    error_message = "existing_monitoring_role_arn must be a concrete IAM role ARN in the aws partition, with an optional path and no wildcards. The rest of this module hardcodes arn:aws:, so aws-us-gov and aws-cn ARNs are not supported."
+  }
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -36,8 +36,8 @@ variable "agents" {
   }
 
   validation {
-    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9-]{1,15}$", k))])
-    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters or hyphens."
+    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9]{1,15}$", k))])
+    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters."
   }
 
   validation {

--- a/modules/native-db-prereqs/variables.tf
+++ b/modules/native-db-prereqs/variables.tf
@@ -1,0 +1,80 @@
+variable "deployment_type" {
+  type        = string
+  description = "Deployment type: 'eks' or 'fargate'. Applies to all agents in this module invocation."
+
+  validation {
+    condition     = contains(["eks", "fargate"], var.deployment_type)
+    error_message = "Variable `deployment_type` must be 'eks' or 'fargate'."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region where resources are created."
+
+  validation {
+    condition     = length(var.region) > 0
+    error_message = "Variable `region` cannot be empty."
+  }
+}
+
+variable "agents" {
+  type = map(object({
+    agent_tags             = list(string)
+    vpc_id                 = string
+    oidc_provider_arn      = optional(string)
+    namespace              = optional(string, "superblocks")
+    service_account_name   = optional(string, "superblocks-agent")
+    existing_role_name     = optional(string)
+    rds_secret_kms_key_arn = optional(string)
+  }))
+  description = "Map of OPA agent configurations keyed by agent name. The map key is the agent name — used to name IAM roles and must be unique per AWS account. Each agent gets its own lifecycle worker role (or attaches to an existing one via existing_role_name) and connector role; all agents share one S3 state bucket per module invocation."
+
+  validation {
+    condition     = length(var.agents) > 0
+    error_message = "At least one agent must be provided."
+  }
+
+  validation {
+    condition     = alltrue([for k in keys(var.agents) : can(regex("^[a-z0-9-]{1,15}$", k))])
+    error_message = "Agent names (map keys) must be 1-15 lowercase alphanumeric characters or hyphens."
+  }
+
+  validation {
+    condition = alltrue([
+      for agent in values(var.agents) :
+      length(agent.agent_tags) > 0 &&
+      alltrue([for t in agent.agent_tags : can(regex("^[a-z0-9-]{1,15}$", t))]) &&
+      length(agent.agent_tags) == length(toset(agent.agent_tags))
+    ])
+    error_message = "Each agent must have at least one unique agent_tag; tag names must be 1-15 lowercase alphanumeric characters or hyphens."
+  }
+
+  validation {
+    condition     = alltrue([for agent in values(var.agents) : can(regex("^vpc-[0-9a-f]+$", agent.vpc_id))])
+    error_message = "Each agent's vpc_id must be a valid VPC ID (e.g. vpc-0123456789abcdef0)."
+  }
+}
+
+variable "name_prefix" {
+  type        = string
+  default     = "sb-native-db"
+  description = "Prefix applied to all IAM roles, policies, and the S3 state bucket created by this module. Defaults to 'sb-native-db'. Override when your organization requires a specific naming convention. Max 16 characters (combined with region (≤14) and account ID (12) the bucket name stays under S3's 63-character limit)."
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{0,14}[a-z0-9]$", var.name_prefix))
+    error_message = "Variable name_prefix must be 2-16 lowercase alphanumeric characters or hyphens, and must not start or end with a hyphen."
+  }
+}
+
+variable "kms_key_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the KMS key for the OpenTofu state bucket. When provided, the bucket is configured with SSE-KMS using this key and IAM KMS permissions are scoped to it. When null, the bucket uses the AWS account default encryption and IAM KMS permissions fall back to Resource:* conditioned on aws:CalledVia s3.amazonaws.com."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags to apply to all resources created by this module. Do not set ManagedBy — the module always enforces ManagedBy = \"superblocks-native-database-lifecycle\", which is required for IAM conditions that scope the lifecycle worker's blast radius."
+}

--- a/modules/native-db/main.tf
+++ b/modules/native-db/main.tf
@@ -1,0 +1,235 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Module sources relative to the dispatch working directory. The OPA image
+  # vendors these modules at fixed paths; this module pins those paths and does
+  # not expose them as inputs. Operators who need a different source write their
+  # own SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG instead of using this module.
+  logical_module_source = "./modules/postgres-managed-database"
+
+  # Aurora is the default physical engine, so a caller who states only where the
+  # database goes gets a Serverless v2 cluster. Standalone RDS is opt-in through
+  # the instance-sizing inputs, which Aurora does not accept; the variable's
+  # validation requires them together and forbids mixing them with deployment.
+  rds_selected = (
+    var.physical_module_inputs.allocated_storage != null ||
+    var.physical_module_inputs.instance_class != null
+  )
+
+  physical_module_source = (
+    local.rds_selected
+    ? "./modules/aws-rds-managed-instance"
+    : "./modules/aws-aurora-managed-cluster"
+  )
+
+  # SSL cert path baked into the Superblocks OPA image.
+  ssl_root_cert = "/etc/ssl/certs/aws-rds-global-bundle.pem"
+
+  # Agent tags carry the profiles this OPA serves. The worker reads them from
+  # SUPERBLOCKS_ORCHESTRATOR_AGENT_TAGS, which the root module renders from its
+  # own superblocks_agent_tags input — so this module derives the string and
+  # exposes it for wiring rather than emitting a second copy of that env var.
+  superblocks_agent_tags = join(",", [for tag in var.agent_tags : "profile:${tag}"])
+
+  # S3 backend base config shared by all operations. The per-operation `key`
+  # is set via merge() below so that logical and physical state land under
+  # separate prefixes in the same bucket.
+  s3_backend_base = {
+    stateBackend = "s3"
+    bucket       = var.state_bucket_name
+    region       = var.region
+    use_lockfile = true
+  }
+
+  # Physical inputs both modules accept. publicly_accessible is always false —
+  # the lifecycle worker IAM policy enforces this at create time regardless of
+  # module input.
+  physical_inputs_shared = {
+    allowed_cidr_blocks       = var.physical_module_inputs.allowed_cidr_blocks
+    backup_retention_period   = var.physical_module_inputs.backup_retention_period
+    delete_automated_backups  = var.physical_module_inputs.delete_automated_backups
+    deletion_protection       = var.physical_module_inputs.deletion_protection
+    monitoring_interval       = var.physical_module_inputs.monitoring_interval
+    monitoring_role_arn       = var.physical_module_inputs.monitoring_role_arn
+    publicly_accessible       = false
+    skip_final_snapshot       = var.physical_module_inputs.skip_final_snapshot
+    source_security_group_ids = var.physical_module_inputs.source_security_group_ids
+    subnet_ids                = var.physical_module_inputs.subnet_ids
+    tags                      = var.physical_module_inputs.tags
+    vpc_id                    = var.physical_module_inputs.vpc_id
+  }
+
+  # An omitted deployment forwards an empty serverless_v2 object so the Aurora
+  # module applies its own Serverless v2 defaults rather than this module
+  # restating a capacity range it would then have to keep in sync.
+  aurora_deployment_json = (
+    var.physical_module_inputs.deployment == null
+    ? jsonencode({ serverless_v2 = {} })
+    : jsonencode(var.physical_module_inputs.deployment)
+  )
+
+  # Aurora and RDS take disjoint capacity arguments and each fails the plan with
+  # "Unsupported argument" on the other's, so only the selected set is
+  # forwarded. The chosen set round-trips through JSON because a conditional
+  # between the two object types would unify them and silently drop keys.
+  physical_inputs_json = (
+    local.rds_selected
+    ? jsonencode(merge(local.physical_inputs_shared,
+      {
+        allocated_storage = var.physical_module_inputs.allocated_storage
+        instance_class    = var.physical_module_inputs.instance_class
+      },
+      # An unstated multi_az is dropped rather than forwarded as null so the RDS
+      # module's own default governs it.
+      { for name, value in { multi_az = var.physical_module_inputs.multi_az } : name => value if value != null },
+    ))
+    : jsonencode(merge(local.physical_inputs_shared, {
+      deployment = jsondecode(local.aurora_deployment_json)
+    }))
+  )
+
+  # Physical module inputs forwarded to ensure_physical_database_instance.
+  physical_inputs = jsondecode(local.physical_inputs_json)
+
+  # Logical module inputs shared by ensure_database and retire_database.
+  #
+  # auth_mode is absent deliberately: the worker sends aws_iam_role itself, and
+  # the logical module no longer accepts the input from operators.
+  #
+  # connector_role_arn is not authored by the caller either — it has one legal
+  # value per OPA and arrives as a module input — but it must still reach the
+  # logical module, because the worker only advertises managed IAM when the
+  # module inputs carry the connector role it was configured with. The Helm
+  # path derives it into these inputs the same way.
+  logical_inputs = {
+    connector_role_arn   = var.connector_role_arn
+    postgres_sslmode     = "verify-full"
+    postgres_sslrootcert = local.ssl_root_cert
+  }
+
+  # Terraform config shared by ensure_database and retire_database (same
+  # logical backend key and module).
+  logical_terraform = {
+    backend = merge(local.s3_backend_base, {
+      key = "${var.key_prefix}/logical/{{profile}}/{{resource_key}}.tfstate"
+    })
+    moduleSelectors = {
+      postgres = {
+        source = local.logical_module_source
+        inputs = local.logical_inputs
+      }
+    }
+  }
+
+  lifecycle_operations = {
+    ensure_database = {
+      backend = "terraform"
+      physicalDatabase = {
+        mode               = "shared_pool"
+        provisionOperation = "ensure_physical_database_instance"
+        onExhausted        = "provision"
+        capacityMax        = var.pool.max_databases
+        securityClass      = "standard"
+      }
+      terraform = local.logical_terraform
+    }
+
+    ensure_physical_database_instance = {
+      backend = "terraform"
+      terraform = {
+        backend = merge(local.s3_backend_base, {
+          key = "${var.key_prefix}/physical/{{profile}}/{{resource_key}}.tfstate"
+        })
+        moduleSelectors = {
+          postgres = {
+            source = local.physical_module_source
+            inputs = local.physical_inputs
+          }
+        }
+      }
+    }
+
+    # Schema migrations run natively inside the OPA process — no Terraform.
+    migrate_schema = { backend = "native_runner" }
+
+    # retire_database reuses the logical Terraform root so tofu destroy targets
+    # the same state as ensure_database.
+    retire_database = {
+      backend   = "terraform"
+      terraform = local.logical_terraform
+    }
+  }
+
+  # One configuration per OPA: engines and operations sit at the document root.
+  # The profiles this OPA serves are deliberately absent — they are declared
+  # once as agent tags, and the worker rejects a profiles key here outright so
+  # the two can never disagree.
+  lifecycle_config = {
+    engines    = ["postgres"]
+    operations = local.lifecycle_operations
+  }
+
+  # Scope the secrets refresolver to only RDS-managed master secrets in this
+  # account and region. The lifecycle worker reads these to connect as the
+  # admin user when provisioning logical databases.
+  allowed_ref_prefixes = [
+    "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!db-",
+    "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster-",
+  ]
+
+  ecs_env_vars = [
+    {
+      name  = "SUPERBLOCKS_ORCHESTRATOR_DATABASE_LIFECYCLE_WORKER_ENABLED"
+      value = "true"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ROOT_DIR"
+      value = "/var/lib/superblocks/database-lifecycle"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_TERRAFORM_BIN"
+      value = "/usr/local/bin/tofu"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_POLL_INTERVAL"
+      value = "30s"
+    },
+    # SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES is deliberately
+    # unset. The worker's own default mirrors the resource graph of the modules
+    # it ships, and an operator-supplied list replaces that default outright
+    # rather than extending it — so a hardcoded list here would fail the first
+    # plan that creates a resource type a newer module release introduced.
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
+      value = "${local.logical_module_source},${local.physical_module_source}"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_AGENT_NAME"
+      value = var.agent_name
+    },
+    {
+      name  = "SUPERBLOCKS_NATIVE_DB_CONNECTOR_ROLE_ARN"
+      value = var.connector_role_arn
+    },
+    {
+      name  = "SUPERBLOCKS_POSTGRES_IAM_ALLOWED_ROLE_ARN_PREFIXES"
+      value = jsonencode([var.connector_role_arn])
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_SSL_MODE"
+      value = "verify-full"
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_SSL_ROOT_CERT"
+      value = local.ssl_root_cert
+    },
+    {
+      name  = "SUPERBLOCKS_SECRETS_REFRESOLVER_ALLOWED_REF_PREFIXES"
+      value = join(",", local.allowed_ref_prefixes)
+    },
+    {
+      name  = "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+      value = jsonencode(local.lifecycle_config)
+    },
+  ]
+}

--- a/modules/native-db/outputs.tf
+++ b/modules/native-db/outputs.tf
@@ -1,0 +1,9 @@
+output "ecs_env_vars" {
+  value       = local.ecs_env_vars
+  description = "Environment variables for the Superblocks Agent ECS container. Pass as superblocks_agent_environment_variables in the terraform_aws_superblocks root module."
+}
+
+output "superblocks_agent_tags" {
+  value       = local.superblocks_agent_tags
+  description = "Agent tags advertising the profiles this OPA serves. Pass as superblocks_agent_tags in the terraform_aws_superblocks root module so the tags the OPA registers cannot drift from the databases it is configured to provision."
+}

--- a/modules/native-db/provider.tf
+++ b/modules/native-db/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/modules/native-db/tests/physical_module.tftest.hcl
+++ b/modules/native-db/tests/physical_module.tftest.hcl
@@ -1,0 +1,344 @@
+# Which physical database a caller gets, and which capacity arguments reach it.
+# Aurora Serverless v2 is what a caller gets without asking; Aurora provisioned
+# and standalone RDS are opt-in. Each physical module rejects the other's
+# capacity arguments, so a mode must never forward the other mode's inputs.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+}
+
+variables {
+  agent_name         = "opa1"
+  agent_tags         = ["nonprod", "production"]
+  connector_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-opa1-connector"
+  key_prefix         = "native-db/opa1"
+  region             = "us-east-1"
+  state_bucket_name  = "sb-native-db-us-east-1-123456789012"
+
+  physical_module_inputs = {
+    monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    vpc_id              = "vpc-0123456789abcdef0"
+  }
+}
+
+run "a_caller_that_names_no_capacity_gets_aurora_serverless" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-aurora-managed-cluster"
+    error_message = "The default physical module must be the Aurora cluster, not standalone RDS."
+  }
+
+  assert {
+    condition = can(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.deployment.serverless_v2)
+    error_message = "An omitted deployment must still ask Aurora for Serverless v2 capacity."
+  }
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs), "allocated_storage")
+    error_message = "Aurora has no allocated_storage variable; forwarding it fails the plan with Unsupported argument."
+  }
+
+  assert {
+    condition = [
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
+    ][0] == "./modules/postgres-managed-database,./modules/aws-aurora-managed-cluster"
+    error_message = "The module-source allowlist must name the physical module this OPA actually dispatches."
+  }
+}
+
+run "a_caller_can_ask_aurora_for_provisioned_instances" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {
+        provisioned = {
+          instance_class = "db.r6g.xlarge"
+          instance_count = 3
+        }
+      }
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-aurora-managed-cluster"
+    error_message = "Provisioned capacity is an Aurora deployment shape, so it must still select the Aurora module."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.deployment.provisioned.instance_class == "db.r6g.xlarge"
+    error_message = "A provisioned instance class must reach the Aurora module unchanged."
+  }
+}
+
+run "a_caller_can_ask_for_standalone_rds_by_sizing_an_instance" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      allocated_storage   = 100
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-rds-managed-instance"
+    error_message = "Instance sizing is RDS-only, so it must select the RDS instance module."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.allocated_storage == 100
+    error_message = "Allocated storage must reach the RDS module unchanged."
+  }
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs), "deployment")
+    error_message = "RDS has no deployment variable; forwarding it fails the plan with Unsupported argument."
+  }
+
+  assert {
+    condition = [
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
+    ][0] == "./modules/postgres-managed-database,./modules/aws-rds-managed-instance"
+    error_message = "The module-source allowlist must follow the selected physical module."
+  }
+}
+
+run "an_rds_instance_needs_both_sizing_inputs" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "aurora_capacity_and_rds_sizing_cannot_be_combined" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      allocated_storage   = 100
+      deployment          = { serverless_v2 = { max_acu = 8 } }
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "an_aurora_deployment_names_exactly_one_capacity_shape" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {
+        provisioned   = { instance_class = "db.r6g.large" }
+        serverless_v2 = { max_acu = 8 }
+      }
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "an_empty_aurora_deployment_is_rejected_rather_than_silently_defaulted" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment          = {}
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+# Both physical modules default monitoring_interval to 60 and reject that
+# without a role, so the rendered inputs have to carry the pair or no database
+# ever provisions.
+run "enhanced_monitoring_reaches_both_physical_modules" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.monitoring_role_arn == "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    error_message = "The Aurora inputs must carry the Enhanced Monitoring role the caller supplied."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.monitoring_interval == 60
+    error_message = "Enhanced Monitoring must stay on by default rather than relying on the physical module's own default."
+  }
+}
+
+run "enhanced_monitoring_without_a_role_is_rejected_here_not_inside_the_worker" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "allocated_storage_must_be_positive" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      allocated_storage   = 0
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "subnet_ids_need_at_least_two_availability_zones" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "vpc_id_must_look_like_a_vpc_id" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "not-a-vpc-id"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+# Agent names land in IAM role names and the worker's pool identity. Restrict
+# to lowercase alphanumeric so later resources that reject hyphens/underscores
+# do not force a rename after databases exist.
+run "agent_name_rejects_hyphens" {
+  command = plan
+
+  variables {
+    agent_name = "opa-1"
+  }
+
+  expect_failures = [var.agent_name]
+}
+
+run "agent_name_rejects_underscores" {
+  command = plan
+
+  variables {
+    agent_name = "opa_1"
+  }
+
+  expect_failures = [var.agent_name]
+}
+
+run "multi_az_alone_cannot_select_rds" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      multi_az            = true
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "deployment_and_multi_az_cannot_be_combined" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {
+        serverless_v2 = {}
+      }
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+      multi_az            = true
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}

--- a/modules/native-db/tests/runtime_config.tftest.hcl
+++ b/modules/native-db/tests/runtime_config.tftest.hcl
@@ -1,0 +1,200 @@
+# The runtime configuration this module hands the OPA container. These
+# assertions track contracts the lifecycle worker enforces at startup: a flat
+# lifecycle document, profiles declared only through agent tags, and defaults
+# the worker owns rather than the operator.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+}
+
+variables {
+  agent_name         = "opa1"
+  agent_tags         = ["nonprod", "production"]
+  connector_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-opa1-connector"
+  key_prefix         = "native-db/opa1"
+  region             = "us-east-1"
+  state_bucket_name  = "sb-native-db-us-east-1-123456789012"
+
+  physical_module_inputs = {
+    monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-native-db-enhanced-monitoring"
+    subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    vpc_id              = "vpc-0123456789abcdef0"
+  }
+}
+
+run "the_lifecycle_document_is_one_flat_configuration" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for key in keys(jsondecode([
+        for env in output.ecs_env_vars : env.value
+        if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+      ][0])) : contains(["engines", "operations"], key)
+    ])
+    error_message = "The worker rejects any key other than engines and operations, including entries and profiles."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).engines == ["postgres"]
+    error_message = "Engines must sit at the document root."
+  }
+
+  assert {
+    condition = alltrue([
+      for operation in ["ensure_database", "ensure_physical_database_instance", "migrate_schema", "retire_database"] :
+      contains(keys(jsondecode([
+        for env in output.ecs_env_vars : env.value
+        if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+      ][0]).operations), operation)
+    ])
+    error_message = "Every operation this OPA serves must sit at the document root."
+  }
+}
+
+run "profiles_are_declared_once_as_agent_tags" {
+  command = plan
+
+  assert {
+    condition     = output.superblocks_agent_tags == "profile:nonprod,profile:production"
+    error_message = "The module must derive the agent tag string so it cannot drift from the lifecycle config."
+  }
+
+  assert {
+    condition = length([
+      for env in output.ecs_env_vars : env.name
+      if env.name == "SUPERBLOCKS_ORCHESTRATOR_AGENT_TAGS"
+    ]) == 0
+    error_message = "The root module already emits SUPERBLOCKS_ORCHESTRATOR_AGENT_TAGS; a second copy would leave the container with two values for one key."
+  }
+}
+
+run "the_worker_owns_its_own_resource_type_allowlist" {
+  command = plan
+
+  assert {
+    condition = length([
+      for env in output.ecs_env_vars : env.name
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_RESOURCE_TYPES"
+    ]) == 0
+    error_message = "An operator-supplied allowlist replaces the worker default outright, so a hardcoded list breaks the first plan that creates a newly published resource type."
+  }
+}
+
+# Match helm/agent databaseLifecycle.pollInterval and the worker's ConfigFromEnv
+# default so Fargate and EKS poll at the same cadence.
+run "poll_interval_matches_helm_and_worker_default" {
+  command = plan
+
+  assert {
+    condition = [
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_POLL_INTERVAL"
+    ][0] == "30s"
+    error_message = "Poll interval must be 30s to match helm/agent databaseLifecycle.pollInterval and the worker default."
+  }
+}
+
+run "the_logical_module_gets_only_the_inputs_it_still_declares" {
+  command = plan
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform.moduleSelectors.postgres.inputs), "auth_mode")
+    error_message = "The worker sends auth_mode itself; sending it here duplicates a value the module no longer accepts from operators."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform.moduleSelectors.postgres.inputs.connector_role_arn == var.connector_role_arn
+    error_message = "The worker only advertises managed IAM when the logical module inputs carry the connector role it was configured with."
+  }
+}
+
+# Backend keys partition by profile only. The lifecycle environment axis is
+# gone from the worker contract; keeping {{environment}} here would expand to
+# "unknown" (or a stale literal) and force a state migration later.
+run "backend_keys_partition_by_profile_not_environment" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform.backend.key == "native-db/opa1/logical/{{profile}}/{{resource_key}}.tfstate"
+    error_message = "Logical state must live under <key_prefix>/logical/{{profile}}/{{resource_key}}.tfstate with no environment segment."
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.backend.key == "native-db/opa1/physical/{{profile}}/{{resource_key}}.tfstate"
+    error_message = "Physical state must live under <key_prefix>/physical/{{profile}}/{{resource_key}}.tfstate with no environment segment."
+  }
+}
+
+# The worker's TerraformOperationBackend no longer declares credentialResolver;
+# an emitted field is silently dropped and drifts from the Helm renderer.
+run "terraform_operations_omit_obsolete_credential_resolver" {
+  command = plan
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_database.terraform), "credentialResolver")
+    error_message = "ensure_database must not emit credentialResolver; the worker no longer declares the field."
+  }
+
+  assert {
+    condition = !contains(keys(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform), "credentialResolver")
+    error_message = "ensure_physical_database_instance must not emit credentialResolver; the worker no longer declares the field."
+  }
+}
+
+run "pool_max_databases_rejects_fractions" {
+  command = plan
+
+  variables {
+    pool = {
+      max_databases = 1.5
+    }
+  }
+
+  expect_failures = [var.pool]
+}
+
+run "agent_tags_reject_commas" {
+  command = plan
+
+  variables {
+    agent_tags = ["non,prod"]
+  }
+
+  expect_failures = [var.agent_tags]
+}
+
+run "agent_tags_reject_mixed_case" {
+  command = plan
+
+  variables {
+    agent_tags = ["NonProd"]
+  }
+
+  expect_failures = [var.agent_tags]
+}

--- a/modules/native-db/variables.tf
+++ b/modules/native-db/variables.tf
@@ -1,0 +1,171 @@
+variable "connector_role_arn" {
+  type        = string
+  description = "ARN of the connector IAM role (from the native-db-prereqs module output agents[<name>].connector_role_arn). Used to authenticate against RDS via IAM at query time."
+}
+
+variable "state_bucket_name" {
+  type        = string
+  description = "Name of the shared S3 state bucket (from the native-db-prereqs module output state_bucket_name). Shared across all OPAs in the same region."
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region where the S3 state bucket and RDS instances live."
+
+  validation {
+    condition     = length(var.region) > 0
+    error_message = "region cannot be empty."
+  }
+}
+
+variable "key_prefix" {
+  type        = string
+  description = "Prefix that namespaces this OPA's OpenTofu state within the shared S3 bucket. Must be unique per OPA — using the agent name as a suffix is recommended (e.g. \"native-db/prod\"). Logical database state lands under <key_prefix>/logical/{{profile}}/... and physical instance state under <key_prefix>/physical/{{profile}}/..."
+
+  validation {
+    condition     = length(var.key_prefix) > 0 && !startswith(var.key_prefix, "/") && !endswith(var.key_prefix, "/")
+    error_message = "key_prefix must be non-empty and must not start or end with a slash."
+  }
+}
+
+variable "agent_name" {
+  type        = string
+  description = "Stable name for this OPA deployment (the agents map key from native-db-prereqs, e.g. \"opa1\"). Used as the physical database pool identity. Must be unique within your AWS account and must not change once databases exist."
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{1,15}$", var.agent_name))
+    error_message = "agent_name must be 1–15 lowercase alphanumeric characters (matching the agents map key constraint in native-db-prereqs)."
+  }
+}
+
+variable "agent_tags" {
+  type        = list(string)
+  description = "Agent profile tags this OPA is registered with (from the native-db-prereqs module output agents[<name>].agent_tags). Used to populate the lifecycle config profiles — must match the agent_tags the OPA advertises to Superblocks. Wildcards are not permitted."
+
+  validation {
+    condition     = length(var.agent_tags) > 0
+    error_message = "agent_tags must contain at least one profile tag."
+  }
+
+  validation {
+    condition = (
+      alltrue([for t in var.agent_tags : can(regex("^[a-z0-9-]{1,15}$", t))]) &&
+      length(var.agent_tags) == length(toset(var.agent_tags))
+    )
+    error_message = "Each agent_tag must be a unique 1-15 lowercase alphanumeric or hyphen string (matching the agents[].agent_tags constraint in native-db-prereqs). Commas and mixed case break the comma-delimited registration string."
+  }
+}
+
+variable "pool" {
+  type = object({
+    max_databases = optional(number, 100)
+  })
+  default     = {}
+  description = "Shared physical pool configuration. max_databases sets the maximum number of logical databases a single RDS instance can hold before a new instance is automatically provisioned. Defaults to 100."
+
+  validation {
+    condition     = var.pool.max_databases > 0 && floor(var.pool.max_databases) == var.pool.max_databases
+    error_message = "pool.max_databases must be a positive integer."
+  }
+}
+
+variable "physical_module_inputs" {
+  type = object({
+    allocated_storage        = optional(number)
+    allowed_cidr_blocks      = optional(list(string), [])
+    backup_retention_period  = optional(number, 7)
+    delete_automated_backups = optional(bool, false)
+    deletion_protection      = optional(bool, true)
+    deployment = optional(object({
+      provisioned = optional(object({
+        instance_class = optional(string, "db.r6g.large")
+        instance_count = optional(number, 2)
+      }))
+      serverless_v2 = optional(object({
+        auto_pause_seconds = optional(number, 300)
+        instance_count     = optional(number, 1)
+        max_acu            = optional(number, 16)
+        min_acu            = optional(number, 0)
+      }))
+    }))
+    instance_class            = optional(string)
+    monitoring_interval       = optional(number, 60)
+    monitoring_role_arn       = optional(string)
+    multi_az                  = optional(bool)
+    skip_final_snapshot       = optional(bool, false)
+    source_security_group_ids = optional(list(string), [])
+    subnet_ids                = list(string)
+    tags                      = optional(map(string), {})
+    vpc_id                    = string
+  })
+  description = <<-EOT
+    Physical database configuration applied to every database this OPA provisions.
+
+    Aurora PostgreSQL is the default. Leaving `deployment` unset provisions Aurora Serverless v2, which scales between a floor and ceiling of Aurora Capacity Units with no instance class to pick. Set `deployment.serverless_v2` to choose that range, or `deployment.provisioned` to run fixed instances instead. `min_acu = 0` lets a cluster pause when idle — appropriate for nonprod, not production.
+
+    Standalone RDS is opt-in: set `allocated_storage` and `instance_class` (and optionally `multi_az`) instead of `deployment`. Aurora manages storage and failover itself and accepts none of those three.
+
+    publicly_accessible is always false and is not configurable — the lifecycle worker IAM policy enforces it regardless.
+
+    Enhanced Monitoring is on at a 60 second interval, which RDS only accepts alongside an IAM role it can assume. Pass the prerequisite stack's `enhanced_monitoring_role_arn` output as `monitoring_role_arn`, or set `monitoring_interval = 0` to turn Enhanced Monitoring off.
+  EOT
+
+  validation {
+    condition = (
+      var.physical_module_inputs.monitoring_interval == 0 ||
+      var.physical_module_inputs.monitoring_role_arn != null
+    )
+    error_message = "physical_module_inputs.monitoring_role_arn is required unless monitoring_interval is 0. Pass the prerequisite stack's enhanced_monitoring_role_arn output, or set monitoring_interval = 0 to disable Enhanced Monitoring."
+  }
+
+  validation {
+    condition = (
+      (var.physical_module_inputs.allocated_storage == null) ==
+      (var.physical_module_inputs.instance_class == null)
+    )
+    error_message = "physical_module_inputs.allocated_storage and instance_class select standalone RDS and must be set together. Omit both to provision Aurora."
+  }
+
+  validation {
+    condition = (
+      var.physical_module_inputs.multi_az == null ||
+      (
+        var.physical_module_inputs.allocated_storage != null &&
+        var.physical_module_inputs.instance_class != null
+      )
+    )
+    error_message = "physical_module_inputs.multi_az is an RDS-only option and must be set together with allocated_storage and instance_class. Omit multi_az to provision Aurora."
+  }
+
+  validation {
+    condition = var.physical_module_inputs.deployment == null || (
+      var.physical_module_inputs.allocated_storage == null &&
+      var.physical_module_inputs.instance_class == null &&
+      var.physical_module_inputs.multi_az == null
+    )
+    error_message = "physical_module_inputs.deployment configures Aurora capacity and cannot be combined with the standalone RDS inputs allocated_storage, instance_class, or multi_az."
+  }
+
+  validation {
+    condition = var.physical_module_inputs.deployment == null || (
+      (var.physical_module_inputs.deployment.provisioned == null ? 0 : 1) +
+      (var.physical_module_inputs.deployment.serverless_v2 == null ? 0 : 1)
+    ) == 1
+    error_message = "physical_module_inputs.deployment must configure exactly one of provisioned or serverless_v2. Omit deployment entirely to accept the Serverless v2 default."
+  }
+
+  validation {
+    condition     = var.physical_module_inputs.allocated_storage == null || try(var.physical_module_inputs.allocated_storage > 0, false)
+    error_message = "physical_module_inputs.allocated_storage must be a positive integer."
+  }
+
+  validation {
+    condition     = length(var.physical_module_inputs.subnet_ids) >= 2
+    error_message = "physical_module_inputs.subnet_ids must contain at least two subnet IDs (the DB subnet group requires subnets in at least two Availability Zones)."
+  }
+
+  validation {
+    condition     = can(regex("^vpc-[0-9a-f]+$", var.physical_module_inputs.vpc_id))
+    error_message = "physical_module_inputs.vpc_id must be a valid VPC ID (e.g. vpc-0123456789abcdef0)."
+  }
+}


### PR DESCRIPTION
## Summary

Stack merge that lands Native DB Terraform for customers: `modules/native-db-prereqs` (one-time IAM/S3 bootstrap) and `modules/native-db` (OPA runtime config), plus the IAM and contract fixes we found while validating them.

## What changed

- [#50](https://github.com/superblocksteam/terraform-aws-superblocks/pull/50): Adds `modules/native-db-prereqs` — per-OPA lifecycle worker and connector roles, shared S3 state bucket, EKS (IRSA) and Fargate trust policies, tag-gated RDS/EC2 provisioning (ENG-4958).
- [#54](https://github.com/superblocksteam/terraform-aws-superblocks/pull/54): Grants `ec2:DescribeRouteTables` so `data.aws_vpc` lookups from the physical modules stop leaving `AccessDenied` in CloudTrail on every plan/apply.
- [#52](https://github.com/superblocksteam/terraform-aws-superblocks/pull/52): Grants observability IAM — account-level Enhanced Monitoring role plus `sb-*` CloudWatch log-group permissions — so physical modules with monitoring defaults don't fail `AccessDenied` (ENG-5014).
- [#53](https://github.com/superblocksteam/terraform-aws-superblocks/pull/53): Adds `modules/native-db` defaulting to Aurora Serverless v2, aligns the rendered worker config with the current lifecycle contract, and fixes connector `rds-db:connect` grants to use hashed profile tokens so runtime queries authorize (ENG-4959, ENG-5117).

---

_Description authored by an AI agent (Cursor) on Wylie's behalf._