### PR TITLE
fix(app-db-prereqs): scope lifecycle IAM per agent

### DIFF
--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -333,8 +333,8 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_state_bucket" {
 #   - ManageMasterUserPassword: master password stored in Secrets Manager
 #     automatically (no plaintext credentials in state).
 #   - PubliclyAccessible: instances must remain VPC-private.
-#   - ManagedBy + Vpc request tags: resources must be tagged at creation
-#     so subsequent mutating-action conditions can scope to them.
+#   - AgentName + ManagedBy + Vpc request tags: resources must be tagged at
+#     creation so subsequent mutating-action conditions can scope to one OPA.
 # StorageEncrypted and DatabaseEngine are enforced via IAM condition keys on
 # create actions where AWS supports them (db* and cluster* resource types).
 # ----------------------------------------------------------------
@@ -399,6 +399,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
             "rds:StorageEncrypted"         = "true"
           }
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
             "rds:DatabaseEngine"       = "postgres"
@@ -420,6 +421,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
             "rds:StorageEncrypted"         = "true"
           }
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
             "rds:DatabaseEngine"       = "aurora-postgresql"
@@ -441,6 +443,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
             "rds:PubliclyAccessible" = "false"
           }
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
             "rds:DatabaseEngine"       = "aurora-postgresql"
@@ -460,6 +463,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
         ]
         Condition = {
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -472,6 +476,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
         Resource = local.rds_resources.subgrp
         Condition = {
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -490,6 +495,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
         ]
         Condition = {
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -505,6 +511,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
         ]
         Condition = {
           StringEqualsIfExists = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -580,6 +587,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
             "rds:ManageMasterUserPassword" = "true"
           }
           StringEquals = {
+            "aws:ResourceTag/AgentName" = each.key
             "aws:ResourceTag/ManagedBy" = local.managed_by_tag
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }
@@ -592,6 +600,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         Resource = local.rds_resources.cluster_snapshot
         Condition = {
           StringEqualsIfExists = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -604,6 +613,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         Resource = local.rds_resources.cluster
         Condition = {
           StringEquals = {
+            "aws:ResourceTag/AgentName" = each.key
             "aws:ResourceTag/ManagedBy" = local.managed_by_tag
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }
@@ -616,6 +626,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         Resource = local.rds_resources.cluster_snapshot
         Condition = {
           StringEqualsIfExists = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -628,6 +639,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         Resource = local.rds_resources.db
         Condition = {
           StringEquals = {
+            "aws:ResourceTag/AgentName" = each.key
             "aws:ResourceTag/ManagedBy" = local.managed_by_tag
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }
@@ -640,6 +652,7 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         Resource = local.rds_resources.snapshot
         Condition = {
           StringEqualsIfExists = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -661,10 +674,12 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         ]
         Condition = {
           StringEquals = {
+            "aws:ResourceTag/AgentName" = each.key
             "aws:ResourceTag/ManagedBy" = local.managed_by_tag
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }
           StringEqualsIfExists = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -686,11 +701,12 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         ]
         Condition = {
           StringEquals = {
+            "aws:ResourceTag/AgentName" = each.key
             "aws:ResourceTag/ManagedBy" = local.managed_by_tag
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }
           "ForAllValues:StringNotEquals" = {
-            "aws:TagKeys" = ["ManagedBy", "Vpc"]
+            "aws:TagKeys" = ["AgentName", "ManagedBy", "Vpc"]
           }
         }
       },
@@ -741,6 +757,7 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           Resource = "${local.ec2_prefix}:security-group/*"
           Condition = {
             StringEquals = {
+              "aws:RequestTag/AgentName" = each.key
               "aws:RequestTag/ManagedBy" = local.managed_by_tag
               "aws:RequestTag/Vpc"       = each.value.vpc_id
             }
@@ -760,6 +777,7 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           Resource = "*"
           Condition = {
             StringEquals = {
+              "aws:ResourceTag/AgentName" = each.key
               "aws:ResourceTag/ManagedBy" = local.managed_by_tag
               "aws:ResourceTag/Vpc"       = each.value.vpc_id
             }
@@ -775,6 +793,7 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           ]
           Condition = {
             StringEquals = {
+              "aws:RequestTag/AgentName" = each.key
               "aws:RequestTag/ManagedBy" = local.managed_by_tag
               "aws:RequestTag/Vpc"       = each.value.vpc_id
               "ec2:CreateAction"         = "CreateSecurityGroup"
@@ -791,10 +810,12 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           ]
           Condition = {
             StringEquals = {
+              "aws:ResourceTag/AgentName" = each.key
               "aws:ResourceTag/ManagedBy" = local.managed_by_tag
               "aws:ResourceTag/Vpc"       = each.value.vpc_id
             }
             StringEqualsIfExists = {
+              "aws:RequestTag/AgentName" = each.key
               "aws:RequestTag/ManagedBy" = local.managed_by_tag
               "aws:RequestTag/Vpc"       = each.value.vpc_id
             }
@@ -810,11 +831,12 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           ]
           Condition = {
             StringEquals = {
+              "aws:ResourceTag/AgentName" = each.key
               "aws:ResourceTag/ManagedBy" = local.managed_by_tag
               "aws:ResourceTag/Vpc"       = each.value.vpc_id
             }
             "ForAllValues:StringNotEquals" = {
-              "aws:TagKeys" = ["ManagedBy", "Vpc"]
+              "aws:TagKeys" = ["AgentName", "ManagedBy", "Vpc"]
             }
           }
         },
@@ -855,6 +877,7 @@ resource "aws_iam_policy" "lifecycle_worker_secrets" {
             "aws:CalledVia" = "rds.amazonaws.com"
           }
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -873,6 +896,7 @@ resource "aws_iam_policy" "lifecycle_worker_secrets" {
             "aws:CalledVia" = "rds.amazonaws.com"
           }
           StringEquals = {
+            "aws:RequestTag/AgentName" = each.key
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
@@ -902,6 +926,7 @@ resource "aws_iam_policy" "lifecycle_worker_secrets" {
         ]
         Condition = {
           StringEquals = {
+            "aws:ResourceTag/AgentName" = each.key
             "aws:ResourceTag/ManagedBy" = local.managed_by_tag
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -1,0 +1,125 @@
+# Every lifecycle worker in a shared account and VPC sees the same sb-* RDS
+# ARN namespace. AgentName is therefore the final authorization boundary:
+# matching ManagedBy and Vpc tags alone must never authorize another OPA's
+# resources.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock"
+    }
+  }
+}
+
+variables {
+  deployment_type = "fargate"
+  region          = "us-east-1"
+
+  agents = {
+    opa1 = {
+      agent_tags = ["production"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+    opa2 = {
+      agent_tags = ["staging"]
+      vpc_id     = "vpc-0123456789abcdef0"
+    }
+  }
+}
+
+run "lifecycle_policies_require_matching_agent_name" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement :
+        try(statement.Condition.StringEquals["aws:ResourceTag/ManagedBy"], null) == null ||
+        try(statement.Condition.StringEquals["aws:ResourceTag/AgentName"], null) == name
+      ])
+    ])
+    error_message = "Every RDS mutation scoped by ManagedBy must also require the lifecycle worker's own AgentName."
+  }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        for statement in concat(
+          jsondecode(aws_iam_policy.lifecycle_worker_rds_provisioning[name].policy).Statement,
+          jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement,
+        ) :
+        (
+          try(statement.Condition.StringEquals["aws:RequestTag/ManagedBy"], null) == null ||
+          try(statement.Condition.StringEquals["aws:RequestTag/AgentName"], null) == name
+          ) && (
+          try(statement.Condition.StringEqualsIfExists["aws:RequestTag/ManagedBy"], null) == null ||
+          try(statement.Condition.StringEqualsIfExists["aws:RequestTag/AgentName"], null) == name
+        )
+      ])
+    ])
+    error_message = "Every RDS create or tag request scoped by ManagedBy must also require the lifecycle worker's own AgentName."
+  }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement :
+        (
+          try(statement.Condition.StringEquals["aws:RequestTag/ManagedBy"], null) == null ||
+          try(statement.Condition.StringEquals["aws:RequestTag/AgentName"], null) == name
+          ) && (
+          try(statement.Condition.StringEquals["aws:ResourceTag/ManagedBy"], null) == null ||
+          try(statement.Condition.StringEquals["aws:ResourceTag/AgentName"], null) == name
+          ) && (
+          try(statement.Condition.StringEqualsIfExists["aws:RequestTag/ManagedBy"], null) == null ||
+          try(statement.Condition.StringEqualsIfExists["aws:RequestTag/AgentName"], null) == name
+        )
+      ])
+    ])
+    error_message = "Every EC2 security-group action scoped by ManagedBy must also require the lifecycle worker's own AgentName."
+  }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_secrets[name].policy).Statement :
+        (
+          try(statement.Condition.StringEquals["aws:RequestTag/ManagedBy"], null) == null ||
+          try(statement.Condition.StringEquals["aws:RequestTag/AgentName"], null) == name
+          ) && (
+          try(statement.Condition.StringEquals["aws:ResourceTag/ManagedBy"], null) == null ||
+          try(statement.Condition.StringEquals["aws:ResourceTag/AgentName"], null) == name
+        )
+      ])
+    ])
+    error_message = "Every RDS-managed secret action scoped by ManagedBy must also require the lifecycle worker's own AgentName."
+  }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        for policy in [
+          jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy),
+          jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy),
+          ] : toset(one([
+            for statement in policy.Statement :
+            statement.Condition["ForAllValues:StringNotEquals"]["aws:TagKeys"]
+            if try(statement.Condition["ForAllValues:StringNotEquals"]["aws:TagKeys"], null) != null
+        ])) == toset(["AgentName", "ManagedBy", "Vpc"])
+      ])
+    ])
+    error_message = "Workers must not be allowed to remove AgentName or the other IAM scoping tags from managed resources."
+  }
+}


### PR DESCRIPTION
## What
Prevent lifecycle workers in the same AWS account and VPC from creating or mutating another OPA's Native Database resources.
This PR is stacked on #56.
## How
- require `AgentName` request tags when creating RDS, Aurora, snapshot, security-group, and RDS-managed secret resources
- require matching `AgentName` resource tags for subsequent mutations and reads
- prevent workers from removing the `AgentName` isolation tag
- test two agents sharing the same VPC to verify each policy remains scoped to its own identity
## Rollout
Land the corresponding orchestrator worker change before enabling these stricter IAM policies. Existing untagged physical resources will not satisfy the new conditions.
## Testing
- `terraform validate`
- `terraform test -filter=tests/agent_isolation.tftest.hcl`