### PR TITLE
fix(app-db-prereqs): remove 15-char length limit from agent_tags

### DIFF
--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -1085,7 +1085,7 @@ resource "aws_iam_policy" "connector" {
     Version = "2012-10-17"
     Statement = [
       for tag in each.value.agent_tags : {
-        Sid    = "ConnectTag${replace(replace(title(tag), "-", ""), "_", "")}"
+        Sid    = "ConnectTag${regexreplace(title(tag), "[^A-Za-z0-9]", "")}"
         Effect = "Allow"
         Action = "rds-db:connect"
         Resource = [

--- a/modules/app-db-prereqs/variables.tf
+++ b/modules/app-db-prereqs/variables.tf
@@ -45,10 +45,10 @@ variable "agents" {
     condition = alltrue([
       for agent in values(var.agents) :
       length(agent.agent_tags) > 0 &&
-      alltrue([for t in agent.agent_tags : can(regex("^[a-z0-9-]{1,15}$", t))]) &&
+      alltrue([for t in agent.agent_tags : length(t) > 0]) &&
       length(agent.agent_tags) == length(toset(agent.agent_tags))
     ])
-    error_message = "Each agent must have at least one unique agent_tag; tag names must be 1-15 lowercase alphanumeric characters or hyphens."
+    error_message = "Each agent must have at least one unique, non-empty agent_tag."
   }
 
   validation {


### PR DESCRIPTION
## Summary

- Removes the `^[a-z0-9-]{1,15}$` character set and length restriction from `agent_tags` validation — customers have tags longer than 15 characters and with characters beyond lowercase alphanumeric/hyphens
- Replaces with a simple non-empty check: `length(t) > 0`
- Switches IAM policy Sid generation from `replace(replace(title(tag), "-", ""), "_", ""))` (only stripped hyphens and underscores) to `regexreplace(title(tag), "[^A-Za-z0-9]", "")` which strips all non-alphanumeric characters, handling any tag value safely
- Updates error message accordingly

## Why

The old validation was too restrictive. IAM Sids must be alphanumeric, but the raw tag never appears in a Sid — it's always transformed via `title()` + the strip regex. So the character restriction on the tag itself was unnecessary. The length restriction was also arbitrary; SHA-256 hash truncation already caps profile tokens at a fixed length regardless of tag length.

Part of ENG-5229.