### PR TITLE
fix(app-db-prereqs): enforce cross-agent agent_tags uniqueness

### DIFF
--- a/examples/app-db-eks/main.tf
+++ b/examples/app-db-eks/main.tf
@@ -24,6 +24,8 @@ module "app_db_prereqs" {
       # the lowercased tag — so "nonprod" creates runtime users as
       # sbndb_6fdc0c6b96ee8a74_<application-token>_runtime.
       # Must match the superblocks_agent_tags configured for this OPA.
+      # Tags must be unique across all agents in this module invocation — two agents
+      # sharing a tag would collide on S3 state keys.
       agent_tags = ["nonprod", "production"]
 
       # VPC the lifecycle worker is allowed to provision RDS/Aurora into.

--- a/examples/app-db-fargate/main.tf
+++ b/examples/app-db-fargate/main.tf
@@ -49,6 +49,8 @@ module "app_db_prereqs" {
       # the lowercased tag — so "nonprod" creates runtime users as
       # sbndb_6fdc0c6b96ee8a74_<application-token>_runtime.
       # Must match the superblocks_agent_tags configured for this OPA.
+      # Tags must be unique across all agents in this module invocation — two agents
+      # sharing a tag would collide on S3 state keys.
       agent_tags = ["nonprod", "production"]
 
       # VPC the lifecycle worker is allowed to provision RDS/Aurora into.

--- a/modules/app-db-prereqs/variables.tf
+++ b/modules/app-db-prereqs/variables.tf
@@ -46,9 +46,17 @@ variable "agents" {
       for agent in values(var.agents) :
       length(agent.agent_tags) > 0 &&
       alltrue([for t in agent.agent_tags : length(t) > 0]) &&
-      length(agent.agent_tags) == length(toset(agent.agent_tags))
+      length(agent.agent_tags) == length(toset([for t in agent.agent_tags : lower(t)]))
     ])
-    error_message = "Each agent must have at least one unique, non-empty agent_tag."
+    error_message = "Each agent must have at least one non-empty agent_tag, with no duplicates within the agent (comparison is case-insensitive)."
+  }
+
+  validation {
+    condition = (
+      length(flatten([for agent in values(var.agents) : agent.agent_tags])) ==
+      length(toset(flatten([for agent in values(var.agents) : [for t in agent.agent_tags : lower(t)]])))
+    )
+    error_message = "agent_tags must be unique across all agents (comparison is case-insensitive)."
   }
 
   validation {


### PR DESCRIPTION
## Summary

- Adds a second `agents` validation block that flattens all `agent_tags` across all agents into one list and checks for duplicates
- Tags must now be unique across agents, not just within each agent's own list

## Why

Two agents sharing the same tag would map to the same profile token, causing S3 state key collisions (`{keyPrefix}/{profile}/{resource_key}.tfstate`) and potential state corruption.

Part of ENG-5229.