### PR TITLE
fix(app-db-prereqs): render agent tag policy Sids

### DIFF
--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -1085,7 +1085,7 @@ resource "aws_iam_policy" "connector" {
     Version = "2012-10-17"
     Statement = [
       for tag in each.value.agent_tags : {
-        Sid    = "ConnectTag${regexreplace(title(tag), "[^A-Za-z0-9]", "")}"
+        Sid    = "ConnectTag${replace(title(tag), "/[^A-Za-z0-9]/", "")}"
         Effect = "Allow"
         Action = "rds-db:connect"
         Resource = [


### PR DESCRIPTION
## Summary
- replace the unsupported `regexreplace` call with Terraform/OpenTofu's slash-delimited regex form of `replace`
- restore `app-db-prereqs` planning for connector policies
## Testing
- `tofu -chdir=modules/app-db-prereqs test`