### PR TITLE
feat(app-db): expose scale-to-zero configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ terraform init
 terraform apply
 ```
 
+### App Databases beta database infrastructure
+
+The Fargate App Databases module always provisions Aurora Serverless v2 during beta. Its customer-facing database infrastructure configuration currently exposes one setting:
+
+```terraform
+module "app_databases" {
+  source = "superblocksteam/superblocks/aws//modules/app-db"
+
+  # Other required App Databases inputs omitted.
+  database_infrastructure = {
+    scale_to_zero = false
+  }
+}
+```
+
+`scale_to_zero` defaults to `false`, which keeps database capacity available when idle. Set it to `true` only when idle suspension and cold-resume latency are acceptable. Low-level Aurora capacity configuration and standalone RDS selection are not supported during beta; `physical_module_inputs` continues to accept networking, monitoring, tags, backup, and security settings.
+
+> **Warning:** Changing `scale_to_zero` after App Databases have been provisioned does not update existing physical databases automatically. Contact Superblocks Support to update existing databases and avoid mixed configurations.
+
+The generated lifecycle configuration requires an OPA image that vendors the shared physical module's `database_infrastructure` input. See [`examples/app-db-fargate`](./examples/app-db-fargate/main.tf) for the complete Fargate configuration and image pin guidance. EKS deployments use the equivalent Helm value `databaseLifecycle.databaseInfrastructure.scaleToZero`; see [`examples/app-db-eks`](./examples/app-db-eks/main.tf) for prerequisite wiring.
+
 ### Advanced Configuration
 
 #### Public Networking

--- a/examples/app-db-eks/main.tf
+++ b/examples/app-db-eks/main.tf
@@ -82,12 +82,19 @@ module "app_db_prereqs" {
   }
 }
 
-# Wire enhanced_monitoring_role_arn into the OPA Helm chart so physical
-# modules can attach Enhanced Monitoring (default monitoring_interval is 60).
-# Without this, plans fail the module precondition even though the IAM role
-# exists:
+# Configure the same App Databases beta database infrastructure concept used by
+# Fargate Terraform in the OPA Helm chart. Keep scaleToZero false for persistent
+# capacity, or set it to true when idle suspension and cold-resume latency are
+# acceptable. Also wire enhanced_monitoring_role_arn so the physical module can
+# attach Enhanced Monitoring (default monitoring_interval is 60).
+#
+# WARNING: Changing scaleToZero after App Databases have been provisioned does
+# not update existing physical databases automatically. Contact Superblocks
+# Support to update existing databases and avoid mixed configurations.
 #
 #   databaseLifecycle:
+#     databaseInfrastructure:
+#       scaleToZero: false
 #     physicalModuleInputs:
 #       monitoring_role_arn: <module.app_db_prereqs.enhanced_monitoring_role_arn>
 #

--- a/examples/app-db-fargate/main.tf
+++ b/examples/app-db-fargate/main.tf
@@ -11,9 +11,10 @@ provider "aws" {
 # in Step 3 below into your existing terraform-aws-superblocks module block
 # (including the superblocks_agent_image pin).
 #
-# IMPORTANT: pin superblocks_agent_image to v1.46.0 or later. modules/app-db
-# emits the flat SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG shape that older images
-# reject at startup with "database lifecycle config entries are required".
+# IMPORTANT: pin superblocks_agent_image to a release that supports the flat
+# SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG shape (v1.46.0 or later) and vendors the
+# physical module database_infrastructure input. An image missing either
+# contract rejects the lifecycle config or fails physical provisioning.
 #
 # IMPORTANT: set existing_role_name (in the agents block below) to your
 # current ECS task role name so app-db-prereqs attaches its policies to
@@ -129,34 +130,19 @@ module "app_db_opa1" {
   # granted; override the value on the agents entry above, never here.
   key_prefix = module.app_db_prereqs.agents["opa1"].key_prefix
 
+  # App Databases beta uses Aurora Serverless v2. Keep false for persistent
+  # capacity, or set true when idle suspension and cold-resume latency are
+  # acceptable.
+  #
+  # WARNING: Changing scale_to_zero after App Databases have been provisioned
+  # does not update existing physical databases automatically. Contact
+  # Superblocks Support to update existing databases and avoid mixed
+  # configurations.
+  database_infrastructure = {
+    scale_to_zero = false
+  }
+
   physical_module_inputs = {
-    # Aurora Serverless v2 is the default: capacity scales between min_acu and
-    # max_acu with no instance class to size. Omit `deployment` entirely to
-    # accept the module defaults, or state the range you want. instance_count
-    # = 2 keeps a second warm instance for immediate failover.
-    #
-    # min_acu = 0 lets a cluster pause when idle. Use it for nonprod, not
-    # production.
-    deployment = {
-      serverless_v2 = {
-        instance_count = 2
-        max_acu        = 32
-        min_acu        = 2
-      }
-    }
-
-    # Aurora with fixed instances instead of Serverless v2:
-    # deployment = {
-    #   provisioned = {
-    #     instance_class = "db.r6g.large"
-    #     instance_count = 2
-    #   }
-    # }
-
-    # Standalone RDS instead of an Aurora cluster (omit deployment above):
-    # allocated_storage = 100
-    # instance_class    = "db.t4g.medium"
-
     vpc_id = "vpc-0123456789abcdef0"
 
     # Subnets in at least two Availability Zones — required by the DB subnet group.
@@ -205,9 +191,10 @@ module "superblocks_opa1" {
   ecs_subnet_ids        = ["subnet-0000000000000001", "subnet-0000000000000002"]
   lb_subnet_ids         = ["subnet-0000000000000001", "subnet-0000000000000002"]
 
-  # App DB requires OPA v1.46.0+. The untagged default image may be older and
-  # will exit on the flat SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG this module emits.
-  superblocks_agent_image = "ghcr.io/superblocksteam/agent:v1.46.0"
+  # App Databases requires an OPA image with the flat lifecycle configuration
+  # and physical module database_infrastructure contracts. Replace this
+  # placeholder with the compatible release supplied by Superblocks.
+  superblocks_agent_image = "ghcr.io/superblocksteam/agent:<APP_DATABASES_COMPATIBLE_VERSION>"
 
   # App DB additions — wire these in from the modules above.
   superblocks_agent_tags                  = module.app_db_opa1.superblocks_agent_tags
@@ -223,6 +210,11 @@ module "superblocks_opa1" {
 output "agents" {
   value       = module.app_db_prereqs.agents
   description = "Per-agent outputs: lifecycle_worker_role_arn (set as the ECS task role ARN), connector_role_arn, and agent_tags."
+}
+
+output "app_databases_database_infrastructure_notice" {
+  value       = module.app_db_opa1.database_infrastructure_notice
+  description = "Apply-visible warning for App Databases database infrastructure changes."
 }
 
 output "enhanced_monitoring_role_arn" {

--- a/modules/app-db/main.tf
+++ b/modules/app-db/main.tf
@@ -7,20 +7,10 @@ locals {
   # own SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG instead of using this module.
   logical_module_source = "./modules/postgres-managed-database"
 
-  # Aurora is the default physical engine, so a caller who states only where the
-  # database goes gets a Serverless v2 cluster. Standalone RDS is opt-in through
-  # the instance-sizing inputs, which Aurora does not accept; the variable's
-  # validation requires them together and forbids mixing them with deployment.
-  rds_selected = (
-    var.physical_module_inputs.allocated_storage != null ||
-    var.physical_module_inputs.instance_class != null
-  )
-
-  physical_module_source = (
-    local.rds_selected
-    ? "./modules/aws-rds-managed-instance"
-    : "./modules/aws-aurora-managed-cluster"
-  )
+  # App Databases beta always provisions Aurora Serverless v2. The shared leaf
+  # module owns the effective capacity defaults and translates the supported
+  # database_infrastructure controls into provider-specific settings.
+  physical_module_source = "./modules/aws-aurora-managed-cluster"
 
   # SSL cert path baked into the Superblocks OPA image.
   ssl_root_cert = "/etc/ssl/certs/aws-rds-global-bundle.pem"
@@ -41,12 +31,15 @@ locals {
     use_lockfile = true
   }
 
-  # Physical inputs both modules accept. publicly_accessible is always false —
-  # the lifecycle worker IAM policy enforces this at create time regardless of
-  # module input.
-  physical_inputs_shared = {
+  # Physical module inputs forwarded to ensure_physical_database_instance.
+  # publicly_accessible is always false — the lifecycle worker IAM policy
+  # enforces this at create time regardless of module input. Capacity settings
+  # are deliberately absent during beta; the leaf module owns all fixed Aurora
+  # Serverless v2 settings.
+  physical_inputs = {
     allowed_cidr_blocks       = var.physical_module_inputs.allowed_cidr_blocks
     backup_retention_period   = var.physical_module_inputs.backup_retention_period
+    database_infrastructure   = var.database_infrastructure
     delete_automated_backups  = var.physical_module_inputs.delete_automated_backups
     deletion_protection       = var.physical_module_inputs.deletion_protection
     monitoring_interval       = var.physical_module_inputs.monitoring_interval
@@ -58,38 +51,6 @@ locals {
     tags                      = var.physical_module_inputs.tags
     vpc_id                    = var.physical_module_inputs.vpc_id
   }
-
-  # An omitted deployment forwards an empty serverless_v2 object so the Aurora
-  # module applies its own Serverless v2 defaults rather than this module
-  # restating a capacity range it would then have to keep in sync.
-  aurora_deployment_json = (
-    var.physical_module_inputs.deployment == null
-    ? jsonencode({ serverless_v2 = {} })
-    : jsonencode(var.physical_module_inputs.deployment)
-  )
-
-  # Aurora and RDS take disjoint capacity arguments and each fails the plan with
-  # "Unsupported argument" on the other's, so only the selected set is
-  # forwarded. The chosen set round-trips through JSON because a conditional
-  # between the two object types would unify them and silently drop keys.
-  physical_inputs_json = (
-    local.rds_selected
-    ? jsonencode(merge(local.physical_inputs_shared,
-      {
-        allocated_storage = var.physical_module_inputs.allocated_storage
-        instance_class    = var.physical_module_inputs.instance_class
-      },
-      # An unstated multi_az is dropped rather than forwarded as null so the RDS
-      # module's own default governs it.
-      { for name, value in { multi_az = var.physical_module_inputs.multi_az } : name => value if value != null },
-    ))
-    : jsonencode(merge(local.physical_inputs_shared, {
-      deployment = jsondecode(local.aurora_deployment_json)
-    }))
-  )
-
-  # Physical module inputs forwarded to ensure_physical_database_instance.
-  physical_inputs = jsondecode(local.physical_inputs_json)
 
   # Logical module inputs shared by ensure_database and retire_database.
   #
@@ -165,9 +126,11 @@ locals {
   # once as agent tags, and the worker rejects a profiles key here outright so
   # the two can never disagree.
   #
-  # Requires OPA image v1.46.0 or later. Older images still expect an `entries`
-  # array and exit at startup with "database lifecycle config entries are
-  # required". Pin superblocks_agent_image when wiring ecs_env_vars into the
+  # Requires an OPA image that supports the flat lifecycle configuration
+  # (v1.46.0 or later) and vendors a physical module with the
+  # database_infrastructure input. Older images either reject this document at
+  # startup or fail physical provisioning with an unsupported module argument.
+  # Pin a compatible superblocks_agent_image when wiring ecs_env_vars into the
   # root module (see examples/app-db-fargate).
   lifecycle_config = {
     engines    = ["postgres"]

--- a/modules/app-db/outputs.tf
+++ b/modules/app-db/outputs.tf
@@ -1,3 +1,8 @@
+output "database_infrastructure_notice" {
+  value       = "WARNING: Changing scale_to_zero after App Databases have been provisioned does not update existing physical databases automatically. Contact Superblocks Support to update existing databases and avoid mixed configurations."
+  description = "Apply-visible notice for the App Databases beta database infrastructure setting. Re-export this output from the calling root module so operators see it after apply."
+}
+
 output "ecs_env_vars" {
   value       = local.ecs_env_vars
   description = "Environment variables for the Superblocks Agent ECS container. Pass as superblocks_agent_environment_variables in the terraform_aws_superblocks root module."

--- a/modules/app-db/tests/database_infrastructure.tftest.hcl
+++ b/modules/app-db/tests/database_infrastructure.tftest.hcl
@@ -1,0 +1,112 @@
+# App Databases beta exposes one database infrastructure control. The app-db
+# module must normalize that control for the shared physical module while
+# keeping low-level capacity and engine selection out of the customer surface.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+}
+
+variables {
+  agent_name         = "opa1"
+  agent_tags         = ["nonprod", "production"]
+  connector_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-opa1-connector"
+  key_prefix         = "app-db/opa1"
+  region             = "us-east-1"
+  state_bucket_name  = "sb-app-db-us-east-1-123456789012"
+
+  physical_module_inputs = {
+    monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
+    subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    vpc_id              = "vpc-0123456789abcdef0"
+  }
+}
+
+run "scale_to_zero_defaults_false" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.database_infrastructure.scale_to_zero == false
+    error_message = "App Databases must keep physical databases active by default."
+  }
+}
+
+run "scale_to_zero_true_reaches_the_physical_module" {
+  command = plan
+
+  variables {
+    database_infrastructure = {
+      scale_to_zero = true
+    }
+  }
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.database_infrastructure.scale_to_zero == true
+    error_message = "The App Databases scale_to_zero setting must reach the shared physical module unchanged."
+  }
+}
+
+run "the_beta_always_selects_aurora" {
+  command = plan
+
+  assert {
+    condition = jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-aurora-managed-cluster"
+    error_message = "The App Databases beta must always select the Aurora physical module."
+  }
+}
+
+run "low_level_aurora_capacity_overrides_are_rejected" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      deployment = {
+        serverless_v2 = {
+          max_acu = 64
+        }
+      }
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "standalone_rds_selection_is_rejected" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      allocated_storage   = 100
+      instance_class      = "db.t4g.medium"
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+    }
+  }
+
+  expect_failures = [var.physical_module_inputs]
+}
+
+run "configuration_change_warning_is_an_output" {
+  command = plan
+
+  assert {
+    condition     = output.database_infrastructure_notice == "WARNING: Changing scale_to_zero after App Databases have been provisioned does not update existing physical databases automatically. Contact Superblocks Support to update existing databases and avoid mixed configurations."
+    error_message = "The module must expose the App Databases reconciliation warning as an output."
+  }
+}

--- a/modules/app-db/tests/physical_module.tftest.hcl
+++ b/modules/app-db/tests/physical_module.tftest.hcl
@@ -1,7 +1,6 @@
-# Which physical database a caller gets, and which capacity arguments reach it.
-# Aurora Serverless v2 is what a caller gets without asking; Aurora provisioned
-# and standalone RDS are opt-in. Each physical module rejects the other's
-# capacity arguments, so a mode must never forward the other mode's inputs.
+# Physical inputs that remain customer-configurable during the App Databases
+# beta. Capacity and engine selection are covered by database_infrastructure
+# contract tests; this file verifies the retained operational inputs.
 
 mock_provider "aws" {
   mock_data "aws_caller_identity" {
@@ -22,11 +21,12 @@ variables {
   physical_module_inputs = {
     monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
     subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+    tags                = { Environment = "production" }
     vpc_id              = "vpc-0123456789abcdef0"
   }
 }
 
-run "a_caller_that_names_no_capacity_gets_aurora_serverless" {
+run "supported_physical_inputs_reach_aurora" {
   command = plan
 
   assert {
@@ -34,95 +34,15 @@ run "a_caller_that_names_no_capacity_gets_aurora_serverless" {
       for env in output.ecs_env_vars : env.value
       if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
     ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-aurora-managed-cluster"
-    error_message = "The default physical module must be the Aurora cluster, not standalone RDS."
-  }
-
-  assert {
-    condition = can(jsondecode([
-      for env in output.ecs_env_vars : env.value
-      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
-    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.deployment.serverless_v2)
-    error_message = "An omitted deployment must still ask Aurora for Serverless v2 capacity."
-  }
-
-  assert {
-    condition = !contains(keys(jsondecode([
-      for env in output.ecs_env_vars : env.value
-      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
-    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs), "allocated_storage")
-    error_message = "Aurora has no allocated_storage variable; forwarding it fails the plan with Unsupported argument."
-  }
-
-  assert {
-    condition = [
-      for env in output.ecs_env_vars : env.value
-      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
-    ][0] == "./modules/postgres-managed-database,./modules/aws-aurora-managed-cluster"
-    error_message = "The module-source allowlist must name the physical module this OPA actually dispatches."
-  }
-}
-
-run "a_caller_can_ask_aurora_for_provisioned_instances" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      deployment = {
-        provisioned = {
-          instance_class = "db.r6g.xlarge"
-          instance_count = 3
-        }
-      }
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
+    error_message = "The App Databases beta must use the Aurora physical module."
   }
 
   assert {
     condition = jsondecode([
       for env in output.ecs_env_vars : env.value
       if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
-    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-aurora-managed-cluster"
-    error_message = "Provisioned capacity is an Aurora deployment shape, so it must still select the Aurora module."
-  }
-
-  assert {
-    condition = jsondecode([
-      for env in output.ecs_env_vars : env.value
-      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
-    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.deployment.provisioned.instance_class == "db.r6g.xlarge"
-    error_message = "A provisioned instance class must reach the Aurora module unchanged."
-  }
-}
-
-run "a_caller_can_ask_for_standalone_rds_by_sizing_an_instance" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      allocated_storage   = 100
-      instance_class      = "db.t4g.medium"
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
-  }
-
-  assert {
-    condition = jsondecode([
-      for env in output.ecs_env_vars : env.value
-      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
-    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.source == "./modules/aws-rds-managed-instance"
-    error_message = "Instance sizing is RDS-only, so it must select the RDS instance module."
-  }
-
-  assert {
-    condition = jsondecode([
-      for env in output.ecs_env_vars : env.value
-      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
-    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.allocated_storage == 100
-    error_message = "Allocated storage must reach the RDS module unchanged."
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.tags.Environment == "production"
+    error_message = "Supported physical module tags must reach Aurora unchanged."
   }
 
   assert {
@@ -130,87 +50,22 @@ run "a_caller_can_ask_for_standalone_rds_by_sizing_an_instance" {
       for env in output.ecs_env_vars : env.value
       if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
     ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs), "deployment")
-    error_message = "RDS has no deployment variable; forwarding it fails the plan with Unsupported argument."
+    error_message = "Low-level Aurora deployment settings must not reach the shared physical module."
   }
 
   assert {
     condition = [
       for env in output.ecs_env_vars : env.value
       if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_ALLOWED_MODULE_SOURCES"
-    ][0] == "./modules/postgres-managed-database,./modules/aws-rds-managed-instance"
-    error_message = "The module-source allowlist must follow the selected physical module."
+    ][0] == "./modules/postgres-managed-database,./modules/aws-aurora-managed-cluster"
+    error_message = "The module-source allowlist must contain the fixed Aurora physical module."
   }
 }
 
-run "an_rds_instance_needs_both_sizing_inputs" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      instance_class      = "db.t4g.medium"
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
-  }
-
-  expect_failures = [var.physical_module_inputs]
-}
-
-run "aurora_capacity_and_rds_sizing_cannot_be_combined" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      allocated_storage   = 100
-      deployment          = { serverless_v2 = { max_acu = 8 } }
-      instance_class      = "db.t4g.medium"
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
-  }
-
-  expect_failures = [var.physical_module_inputs]
-}
-
-run "an_aurora_deployment_names_exactly_one_capacity_shape" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      deployment = {
-        provisioned   = { instance_class = "db.r6g.large" }
-        serverless_v2 = { max_acu = 8 }
-      }
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
-  }
-
-  expect_failures = [var.physical_module_inputs]
-}
-
-run "an_empty_aurora_deployment_is_rejected_rather_than_silently_defaulted" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      deployment          = {}
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
-  }
-
-  expect_failures = [var.physical_module_inputs]
-}
-
-# Both physical modules default monitoring_interval to 60 and reject that
+# The physical module defaults monitoring_interval to 60 and rejects that
 # without a role, so the rendered inputs have to carry the pair or no database
 # ever provisions.
-run "enhanced_monitoring_reaches_both_physical_modules" {
+run "enhanced_monitoring_reaches_the_physical_module" {
   command = plan
 
   assert {
@@ -237,22 +92,6 @@ run "enhanced_monitoring_without_a_role_is_rejected_here_not_inside_the_worker" 
     physical_module_inputs = {
       subnet_ids = ["subnet-0000000000000001", "subnet-0000000000000002"]
       vpc_id     = "vpc-0123456789abcdef0"
-    }
-  }
-
-  expect_failures = [var.physical_module_inputs]
-}
-
-run "allocated_storage_must_be_positive" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      allocated_storage   = 0
-      instance_class      = "db.t4g.medium"
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
     }
   }
 
@@ -308,37 +147,4 @@ run "agent_name_rejects_underscores" {
   }
 
   expect_failures = [var.agent_name]
-}
-
-run "multi_az_alone_cannot_select_rds" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      multi_az            = true
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
-  }
-
-  expect_failures = [var.physical_module_inputs]
-}
-
-run "deployment_and_multi_az_cannot_be_combined" {
-  command = plan
-
-  variables {
-    physical_module_inputs = {
-      deployment = {
-        serverless_v2 = {}
-      }
-      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
-      multi_az            = true
-      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
-      vpc_id              = "vpc-0123456789abcdef0"
-    }
-  }
-
-  expect_failures = [var.physical_module_inputs]
 }

--- a/modules/app-db/variables.tf
+++ b/modules/app-db/variables.tf
@@ -69,25 +69,26 @@ variable "pool" {
   }
 }
 
+variable "database_infrastructure" {
+  type = object({
+    scale_to_zero = optional(bool, false)
+  })
+  default     = {}
+  description = <<-EOT
+    App Databases beta database infrastructure configuration. scale_to_zero defaults to false so Aurora Serverless v2 capacity remains available when idle. Set it to true only when idle suspension and cold-resume latency are acceptable.
+
+    WARNING: Changing scale_to_zero after App Databases have been provisioned does not update existing physical databases automatically. Contact Superblocks Support to update existing databases and avoid mixed configurations.
+  EOT
+}
+
 variable "physical_module_inputs" {
   type = object({
-    allocated_storage        = optional(number)
-    allowed_cidr_blocks      = optional(list(string), [])
-    backup_retention_period  = optional(number, 7)
-    delete_automated_backups = optional(bool, false)
-    deletion_protection      = optional(bool, true)
-    deployment = optional(object({
-      provisioned = optional(object({
-        instance_class = optional(string, "db.r6g.large")
-        instance_count = optional(number, 2)
-      }))
-      serverless_v2 = optional(object({
-        auto_pause_seconds = optional(number, 300)
-        instance_count     = optional(number, 1)
-        max_acu            = optional(number, 16)
-        min_acu            = optional(number, 0)
-      }))
-    }))
+    allocated_storage         = optional(number)
+    allowed_cidr_blocks       = optional(list(string), [])
+    backup_retention_period   = optional(number, 7)
+    delete_automated_backups  = optional(bool, false)
+    deletion_protection       = optional(bool, true)
+    deployment                = optional(any)
     instance_class            = optional(string)
     monitoring_interval       = optional(number, 60)
     monitoring_role_arn       = optional(string)
@@ -99,15 +100,13 @@ variable "physical_module_inputs" {
     vpc_id                    = string
   })
   description = <<-EOT
-    Physical database configuration applied to every database this OPA provisions.
-
-    Aurora PostgreSQL is the default. Leaving `deployment` unset provisions Aurora Serverless v2, which scales between a floor and ceiling of Aurora Capacity Units with no instance class to pick. Set `deployment.serverless_v2` to choose that range, or `deployment.provisioned` to run fixed instances instead. `min_acu = 0` lets a cluster pause when idle — appropriate for nonprod, not production.
-
-    Standalone RDS is opt-in: set `allocated_storage` and `instance_class` (and optionally `multi_az`) instead of `deployment`. Aurora manages storage and failover itself and accepts none of those three.
+    Networking, monitoring, tags, backup, and security configuration applied to every physical database this OPA provisions.
 
     publicly_accessible is always false and is not configurable — the lifecycle worker IAM policy enforces it regardless.
 
     Enhanced Monitoring is on at a 60 second interval, which RDS only accepts alongside an IAM role it can assume. Pass the prerequisite stack's `enhanced_monitoring_role_arn` output as `monitoring_role_arn`, or set `monitoring_interval = 0` to turn Enhanced Monitoring off.
+
+    App Databases beta always provisions Aurora Serverless v2. Low-level Aurora capacity configuration through `deployment`, and standalone RDS selection through `allocated_storage`, `instance_class`, or `multi_az`, are not supported. Use `database_infrastructure.scale_to_zero` for the supported beta lifecycle control.
   EOT
 
   validation {
@@ -120,43 +119,12 @@ variable "physical_module_inputs" {
 
   validation {
     condition = (
-      (var.physical_module_inputs.allocated_storage == null) ==
-      (var.physical_module_inputs.instance_class == null)
-    )
-    error_message = "physical_module_inputs.allocated_storage and instance_class select standalone RDS and must be set together. Omit both to provision Aurora."
-  }
-
-  validation {
-    condition = (
-      var.physical_module_inputs.multi_az == null ||
-      (
-        var.physical_module_inputs.allocated_storage != null &&
-        var.physical_module_inputs.instance_class != null
-      )
-    )
-    error_message = "physical_module_inputs.multi_az is an RDS-only option and must be set together with allocated_storage and instance_class. Omit multi_az to provision Aurora."
-  }
-
-  validation {
-    condition = var.physical_module_inputs.deployment == null || (
       var.physical_module_inputs.allocated_storage == null &&
+      var.physical_module_inputs.deployment == null &&
       var.physical_module_inputs.instance_class == null &&
       var.physical_module_inputs.multi_az == null
     )
-    error_message = "physical_module_inputs.deployment configures Aurora capacity and cannot be combined with the standalone RDS inputs allocated_storage, instance_class, or multi_az."
-  }
-
-  validation {
-    condition = var.physical_module_inputs.deployment == null || (
-      (var.physical_module_inputs.deployment.provisioned == null ? 0 : 1) +
-      (var.physical_module_inputs.deployment.serverless_v2 == null ? 0 : 1)
-    ) == 1
-    error_message = "physical_module_inputs.deployment must configure exactly one of provisioned or serverless_v2. Omit deployment entirely to accept the Serverless v2 default."
-  }
-
-  validation {
-    condition     = var.physical_module_inputs.allocated_storage == null || try(var.physical_module_inputs.allocated_storage > 0, false)
-    error_message = "physical_module_inputs.allocated_storage must be a positive integer."
+    error_message = "App Databases beta always uses Aurora Serverless v2. Do not set physical_module_inputs.deployment, allocated_storage, instance_class, or multi_az; use database_infrastructure.scale_to_zero for the supported beta lifecycle control."
   }
 
   validation {


### PR DESCRIPTION
## What

Exposes the App Databases beta infrastructure configuration to Terraform/Fargate customers as one setting: `database_infrastructure.scale_to_zero`. App Databases uses Aurora Serverless v2 during beta; low-level capacity values and standalone RDS selection are no longer customer-facing choices in this module.

This is PR 2 of 5. It depends on [terraform-superblocks-databases #27](https://github.com/superblocksteam/terraform-superblocks-databases/pull/27) and an OPA release that vendors that module contract.

## How

- defaults `scale_to_zero` to `false`
- forwards the normalized input into physical module configuration
- rejects legacy low-level Aurora capacity and standalone-RDS selectors
- documents the non-reconciliation warning in module docs, examples, and an apply output
- keeps networking, monitoring, backup, security, and tags configurable

## Testing

- `tofu test` in `modules/app-db` — 23 passed

_Prepared by a Cursor agent._

Made with [Cursor](https://cursor.com)