### PR TITLE
feat(app-db): mandate ownership and APN tags on all app database resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## Unreleased
+
+### Breaking / upgrade notes
+
+#### App Database ownership and APN tags (`app-db`, `app-db-prereqs`)
+
+`app-db-prereqs` and `app-db` now always stamp `superblocks:owned=true` and
+`aws-apn-id=pc:ctelqp437y3cvjkv5rv0z2w4f` on resources they create (or render
+into runtime physical-module inputs). The lifecycle worker IAM policies also
+protect those keys from removal (and require the canonical values when the
+worker writes them via tag APIs).
+
+**Upgrade together.** Once `app-db-prereqs` protects the ownership keys, do not
+pin `app-db` to an older release that omits them from `physical_module_inputs.tags`.
+That skew fails closed on later physical applies: OpenTofu tries to remove the
+tags, and `rds:RemoveTagsFromResource` / `ec2:DeleteTags` are denied.
+
+Tags land on new creates and on the next apply that touches that state. There
+is no automatic backfill of idle fleets.
+
+`existing_role_name` still attaches policies to a customer-provided lifecycle
+role; this module does **not** tag that existing role. Ownership tags apply to
+resources this module creates (policies, connector/monitoring roles when
+created, state bucket) and to runtime App DB resources via `app-db` / Helm
+`physicalModuleTags`.

--- a/examples/app-db-eks/main.tf
+++ b/examples/app-db-eks/main.tf
@@ -76,7 +76,9 @@ module "app_db_prereqs" {
   # from the first instead of creating another copy.
   # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
 
-  # Optional: additional tags applied to all resources created by this module.
+  # Optional: additional inventory tags applied to all resources created by this module.
+  # Do not set ManagedBy, superblocks:owned, or aws-apn-id — app-db-prereqs always
+  # enforces those reserved keys (see output "tags").
   tags = {
     Environment = "production"
   }
@@ -85,13 +87,16 @@ module "app_db_prereqs" {
 # Wire enhanced_monitoring_role_arn into the OPA Helm chart so physical
 # modules can attach Enhanced Monitoring (default monitoring_interval is 60).
 # Without this, plans fail the module precondition even though the IAM role
-# exists:
+# exists. Also pass tags into databaseLifecycle.physicalModuleTags so runtime
+# Aurora carries ManagedBy, superblocks:owned, and aws-apn-id (the Helm chart
+# does not inject the ownership pair by default):
 #
 #   databaseLifecycle:
+#     physicalModuleTags: <module.app_db_prereqs.tags>
 #     physicalModuleInputs:
 #       monitoring_role_arn: <module.app_db_prereqs.enhanced_monitoring_role_arn>
 #
-# Or opt out with monitoring_interval: 0.
+# Or opt out of Enhanced Monitoring with monitoring_interval: 0.
 
 output "agents" {
   value       = module.app_db_prereqs.agents
@@ -106,4 +111,9 @@ output "enhanced_monitoring_role_arn" {
 output "state_bucket_name" {
   value       = module.app_db_prereqs.state_bucket_name
   description = "S3 bucket used by the OPA lifecycle workers to store OpenTofu state."
+}
+
+output "tags" {
+  value       = module.app_db_prereqs.tags
+  description = "Pass to OPA Helm as databaseLifecycle.physicalModuleTags so runtime Aurora/RDS carry ManagedBy, superblocks:owned, and aws-apn-id. The Helm chart does not inject the ownership pair by default."
 }

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -45,7 +45,24 @@ locals {
   # Tagging
   # ----------------------------------------------------------------
   managed_by_tag = "superblocks-app-database-lifecycle"
-  tags           = merge(var.tags, { ManagedBy = local.managed_by_tag })
+
+  # Ownership and AWS Partner Network attribution, mandatory on every AWS
+  # resource Superblocks creates in a customer account. They are merged over
+  # var.tags rather than defaulted into it so no caller can drop them, and the
+  # same pair is applied to the runtime databases by the app-db module.
+  ownership_tags = {
+    "aws-apn-id"        = "pc:ctelqp437y3cvjkv5rv0z2w4f"
+    "superblocks:owned" = "true"
+  }
+
+  tags = merge(var.tags, local.ownership_tags, { ManagedBy = local.managed_by_tag })
+
+  # Tag keys the worker may never strip from a resource it manages: the three
+  # keys every mutating-action condition scopes on, plus the ownership pair the
+  # app-db module stamps on the databases themselves. Removing any of them would
+  # either orphan the resource from the worker's own permissions or erase the
+  # attribution this module exists to guarantee.
+  protected_tag_keys = concat(["AgentName", "ManagedBy", "Vpc"], keys(local.ownership_tags))
 
   # ----------------------------------------------------------------
   # RDS and EC2 ARN helpers (region + account scoped, not agent scoped)
@@ -252,6 +269,8 @@ resource "aws_iam_policy" "lifecycle_worker_assume_connector" {
       }
     ]
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lifecycle_worker_assume_connector" {
@@ -318,6 +337,8 @@ resource "aws_iam_policy" "lifecycle_worker_state_bucket" {
       local.state_bucket_kms_statement != null ? [local.state_bucket_kms_statement] : []
     )
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lifecycle_worker_state_bucket" {
@@ -535,6 +556,8 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
       },
     ]
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_provisioning" {
@@ -679,14 +702,16 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }
           StringEqualsIfExists = {
-            "aws:RequestTag/AgentName" = each.key
-            "aws:RequestTag/ManagedBy" = local.managed_by_tag
-            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "aws:RequestTag/AgentName"         = each.key
+            "aws:RequestTag/ManagedBy"         = local.managed_by_tag
+            "aws:RequestTag/Vpc"               = each.value.vpc_id
+            "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+            "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
           }
         }
       },
       {
-        Sid    = "RdsRemoveTagsExceptScopingTags"
+        Sid    = "RdsRemoveTagsExceptProtectedTags"
         Effect = "Allow"
         Action = "rds:RemoveTagsFromResource"
         Resource = [
@@ -706,12 +731,36 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
             "aws:ResourceTag/Vpc"       = each.value.vpc_id
           }
           "ForAllValues:StringNotEquals" = {
-            "aws:TagKeys" = ["AgentName", "ManagedBy", "Vpc"]
+            "aws:TagKeys" = local.protected_tag_keys
+          }
+        }
+      },
+      {
+        # Explicit Deny so stripping scoping/ownership tags fails closed with a
+        # named Sid in IAM diagnostics, not only an unmatched Allow.
+        Sid    = "DenyRemoveProtectedTags"
+        Effect = "Deny"
+        Action = "rds:RemoveTagsFromResource"
+        Resource = [
+          local.rds_resources.cluster,
+          local.rds_resources.cluster_pg,
+          local.rds_resources.cluster_snapshot,
+          local.rds_resources.db,
+          local.rds_resources.pg_sb,
+          local.rds_resources.pg_all,
+          local.rds_resources.snapshot,
+          local.rds_resources.subgrp,
+        ]
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:TagKeys" = local.protected_tag_keys
           }
         }
       },
     ]
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_mutation" {
@@ -815,14 +864,16 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
               "aws:ResourceTag/Vpc"       = each.value.vpc_id
             }
             StringEqualsIfExists = {
-              "aws:RequestTag/AgentName" = each.key
-              "aws:RequestTag/ManagedBy" = local.managed_by_tag
-              "aws:RequestTag/Vpc"       = each.value.vpc_id
+              "aws:RequestTag/AgentName"         = each.key
+              "aws:RequestTag/ManagedBy"         = local.managed_by_tag
+              "aws:RequestTag/Vpc"               = each.value.vpc_id
+              "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+              "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
             }
           }
         },
         {
-          Sid    = "Ec2DeleteTagsExceptScopingTags"
+          Sid    = "Ec2DeleteTagsExceptProtectedTags"
           Effect = "Allow"
           Action = ["ec2:DeleteTags"]
           Resource = [
@@ -836,7 +887,31 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
               "aws:ResourceTag/Vpc"       = each.value.vpc_id
             }
             "ForAllValues:StringNotEquals" = {
-              "aws:TagKeys" = ["AgentName", "ManagedBy", "Vpc"]
+              "aws:TagKeys" = local.protected_tag_keys
+            }
+          }
+        },
+        {
+          # Explicit Deny so stripping scoping/ownership tags fails closed with a
+          # named Sid in IAM diagnostics, not only an unmatched Allow. Scoped to
+          # this agent's ManagedBy/AgentName/Vpc resources so attaching these
+          # policies via existing_role_name cannot Deny DeleteTags on unrelated
+          # security groups in the same account/region.
+          Sid    = "DenyDeleteProtectedTags"
+          Effect = "Deny"
+          Action = ["ec2:DeleteTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/AgentName" = each.key
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+            "ForAnyValue:StringEquals" = {
+              "aws:TagKeys" = local.protected_tag_keys
             }
           }
         },
@@ -844,6 +919,8 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
       local.agent_ec2_create_sg_vpc_statements[each.key]
     )
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lifecycle_worker_ec2_provisioning" {
@@ -935,6 +1012,8 @@ resource "aws_iam_policy" "lifecycle_worker_secrets" {
       local.agent_rds_secret_kms_statements[each.key],
     ]
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lifecycle_worker_secrets" {
@@ -970,9 +1049,32 @@ resource "aws_iam_policy" "lifecycle_worker_observability" {
           "logs:ListTagsForResource",
           "logs:PutRetentionPolicy",
           "logs:TagResource",
-          "logs:UntagResource",
         ]
         Resource = local.app_db_cloudwatch_log_group_arn_patterns
+      },
+      {
+        Sid      = "CloudWatchUntagExceptProtectedTags"
+        Effect   = "Allow"
+        Action   = "logs:UntagResource"
+        Resource = local.app_db_cloudwatch_log_group_arn_patterns
+        Condition = {
+          "ForAllValues:StringNotEquals" = {
+            "aws:TagKeys" = local.protected_tag_keys
+          }
+        }
+      },
+      {
+        # Explicit Deny so stripping ownership/scoping tags from App DB log
+        # groups fails closed with a named Sid, matching RDS/EC2 tag removal.
+        Sid      = "DenyUntagProtectedTags"
+        Effect   = "Deny"
+        Action   = "logs:UntagResource"
+        Resource = local.app_db_cloudwatch_log_group_arn_patterns
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "aws:TagKeys" = local.protected_tag_keys
+          }
+        }
       },
       # The provider reads aws_cloudwatch_log_group through DescribeLogGroups,
       # which AWS authorizes only against "*" — an iam:SimulateCustomPolicy run
@@ -1002,6 +1104,8 @@ resource "aws_iam_policy" "lifecycle_worker_observability" {
       },
     ]
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lifecycle_worker_observability" {
@@ -1120,6 +1224,8 @@ resource "aws_iam_policy" "connector" {
       }
     ]
   })
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "connector" {

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -520,6 +520,13 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
             "aws:RequestTag/ManagedBy" = local.managed_by_tag
             "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
+          # Ownership values when present must be canonical. Without this,
+          # RdsTagOnCreate ORs with RdsAddTagsToManagedResources and bypasses
+          # the mutation-policy ownership check on the same action/resources.
+          StringEqualsIfExists = {
+            "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+            "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
+          }
         }
       },
       {
@@ -532,9 +539,11 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
         ]
         Condition = {
           StringEqualsIfExists = {
-            "aws:RequestTag/AgentName" = each.key
-            "aws:RequestTag/ManagedBy" = local.managed_by_tag
-            "aws:RequestTag/Vpc"       = each.value.vpc_id
+            "aws:RequestTag/AgentName"         = each.key
+            "aws:RequestTag/ManagedBy"         = local.managed_by_tag
+            "aws:RequestTag/Vpc"               = each.value.vpc_id
+            "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+            "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
           }
         }
       },
@@ -847,6 +856,13 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
               "aws:RequestTag/Vpc"       = each.value.vpc_id
               "ec2:CreateAction"         = "CreateSecurityGroup"
             }
+            # Same overlapping-Allow bypass as RdsTagOnCreate: without this,
+            # CreateTags on create can write non-canonical ownership values
+            # even though Ec2CreateTagsOnManagedResources checks them.
+            StringEqualsIfExists = {
+              "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+              "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
+            }
           }
         },
         {
@@ -886,6 +902,12 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
               "aws:ResourceTag/ManagedBy" = local.managed_by_tag
               "aws:ResourceTag/Vpc"       = each.value.vpc_id
             }
+            # TagKeys must be present: a DeleteTags call with no Tags parameter
+            # clears every user tag and omits aws:TagKeys, which makes
+            # ForAllValues:StringNotEquals evaluate true (vacuous truth).
+            Null = {
+              "aws:TagKeys" = "false"
+            }
             "ForAllValues:StringNotEquals" = {
               "aws:TagKeys" = local.protected_tag_keys
             }
@@ -912,6 +934,28 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
             }
             "ForAnyValue:StringEquals" = {
               "aws:TagKeys" = local.protected_tag_keys
+            }
+          }
+        },
+        {
+          # DeleteTags with no Tags parameter clears every user-defined tag and
+          # omits aws:TagKeys from the request context. ForAnyValue:StringEquals
+          # then does not match DenyDeleteProtectedTags, so fail closed here.
+          Sid    = "DenyDeleteTagsWhenTagKeysAbsent"
+          Effect = "Deny"
+          Action = ["ec2:DeleteTags"]
+          Resource = [
+            "${local.ec2_prefix}:security-group/*",
+            "${local.ec2_prefix}:security-group-rule/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:ResourceTag/AgentName" = each.key
+              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
+              "aws:ResourceTag/Vpc"       = each.value.vpc_id
+            }
+            Null = {
+              "aws:TagKeys" = "true"
             }
           }
         },
@@ -1048,9 +1092,23 @@ resource "aws_iam_policy" "lifecycle_worker_observability" {
           "logs:DeleteLogGroup",
           "logs:ListTagsForResource",
           "logs:PutRetentionPolicy",
-          "logs:TagResource",
         ]
         Resource = local.app_db_cloudwatch_log_group_arn_patterns
+      },
+      {
+        # TagResource is split out so ownership request-tag values can be
+        # constrained. Leaving it unconditional next to CreateLogGroup would
+        # let the worker overwrite superblocks:owned / aws-apn-id.
+        Sid      = "CloudWatchTagResourceWithCanonicalOwnership"
+        Effect   = "Allow"
+        Action   = "logs:TagResource"
+        Resource = local.app_db_cloudwatch_log_group_arn_patterns
+        Condition = {
+          StringEqualsIfExists = {
+            "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+            "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
+          }
+        }
       },
       {
         Sid      = "CloudWatchUntagExceptProtectedTags"

--- a/modules/app-db-prereqs/outputs.tf
+++ b/modules/app-db-prereqs/outputs.tf
@@ -22,5 +22,5 @@ output "state_bucket_name" {
 
 output "tags" {
   value       = local.tags
-  description = "Tags applied to all resources created by this module. Pass to the app-db module's physical_module_inputs.tags to tag RDS instances with the same values."
+  description = "Tags applied to all resources created by this module, including the reserved ManagedBy, superblocks:owned, and aws-apn-id keys. Pass to the app-db module's physical_module_inputs.tags (or databaseLifecycle.physicalModuleTags) so runtime App DB resources carry the same values; app-db also re-enforces the ownership pair independently."
 }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -113,13 +113,70 @@ run "lifecycle_policies_require_matching_agent_name" {
         for policy in [
           jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy),
           jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy),
+          jsondecode(aws_iam_policy.lifecycle_worker_observability[name].policy),
           ] : toset(one([
             for statement in policy.Statement :
             statement.Condition["ForAllValues:StringNotEquals"]["aws:TagKeys"]
             if try(statement.Condition["ForAllValues:StringNotEquals"]["aws:TagKeys"], null) != null
-        ])) == toset(["AgentName", "ManagedBy", "Vpc"])
+        ])) == toset(["AgentName", "ManagedBy", "Vpc", "aws-apn-id", "superblocks:owned"])
       ])
     ])
-    error_message = "Workers must not be allowed to remove AgentName or the other IAM scoping tags from managed resources."
+    error_message = "Workers must not be allowed to remove AgentName, the other IAM scoping tags, or the ownership pair from managed resources (including CloudWatch log groups)."
+  }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        length([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement : statement
+          if try(statement.Sid, null) == "DenyRemoveProtectedTags" &&
+          try(statement.Effect, null) == "Deny" &&
+          try(statement.Action, null) == "rds:RemoveTagsFromResource" &&
+          try(toset(statement.Condition["ForAnyValue:StringEquals"]["aws:TagKeys"]), null) == toset(["AgentName", "ManagedBy", "Vpc", "aws-apn-id", "superblocks:owned"])
+        ]) == 1,
+        length([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement : statement
+          if try(statement.Sid, null) == "DenyDeleteProtectedTags" &&
+          try(statement.Effect, null) == "Deny" &&
+          contains(try(tolist(statement.Action), [statement.Action]), "ec2:DeleteTags") &&
+          try(statement.Condition.StringEquals["aws:ResourceTag/AgentName"], null) == name &&
+          try(statement.Condition.StringEquals["aws:ResourceTag/ManagedBy"], null) == "superblocks-app-database-lifecycle" &&
+          try(statement.Condition.StringEquals["aws:ResourceTag/Vpc"], null) == var.agents[name].vpc_id &&
+          try(toset(statement.Condition["ForAnyValue:StringEquals"]["aws:TagKeys"]), null) == toset(["AgentName", "ManagedBy", "Vpc", "aws-apn-id", "superblocks:owned"])
+        ]) == 1,
+        length([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability[name].policy).Statement : statement
+          if try(statement.Sid, null) == "DenyUntagProtectedTags" &&
+          try(statement.Effect, null) == "Deny" &&
+          try(statement.Action, null) == "logs:UntagResource" &&
+          try(toset(statement.Condition["ForAnyValue:StringEquals"]["aws:TagKeys"]), null) == toset(["AgentName", "ManagedBy", "Vpc", "aws-apn-id", "superblocks:owned"])
+        ]) == 1,
+      ])
+    ])
+    error_message = "RDS, EC2, and CloudWatch mutation policies must Deny removing protected tag keys via named Sids; EC2 Deny must also require this agent's ResourceTag scope."
+  }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        try(one([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement :
+          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "RdsAddTagsToManagedResources"
+          ])["aws:RequestTag/superblocks:owned"], null) == "true",
+        try(one([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement :
+          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "RdsAddTagsToManagedResources"
+          ])["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f",
+        try(one([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement :
+          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "Ec2CreateTagsOnManagedResources"
+          ])["aws:RequestTag/superblocks:owned"], null) == "true",
+        try(one([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement :
+          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "Ec2CreateTagsOnManagedResources"
+          ])["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f",
+      ])
+    ])
+    error_message = "When the worker writes ownership tags via AddTags/CreateTags, IAM must require the canonical values (StringEqualsIfExists)."
   }
 }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -156,27 +156,62 @@ run "lifecycle_policies_require_matching_agent_name" {
     error_message = "RDS, EC2, and CloudWatch mutation policies must Deny removing protected tag keys via named Sids; EC2 Deny must also require this agent's ResourceTag scope."
   }
 
+  # AWS DeleteTags with no Tags parameter clears every user tag and omits
+  # aws:TagKeys. ForAllValues:StringNotEquals then evaluates true (vacuous)
+  # while ForAnyValue:StringEquals does not match — so protected-key Deny alone
+  # is not enough. Require TagKeys to be present on the Allow, and Deny when it
+  # is absent, both scoped to this agent's resources.
   assert {
     condition = alltrue([
       for name in keys(var.agents) : alltrue([
         try(one([
-          for statement in jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement :
-          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "RdsAddTagsToManagedResources"
-          ])["aws:RequestTag/superblocks:owned"], null) == "true",
-        try(one([
-          for statement in jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement :
-          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "RdsAddTagsToManagedResources"
-          ])["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f",
-        try(one([
           for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement :
-          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "Ec2CreateTagsOnManagedResources"
-          ])["aws:RequestTag/superblocks:owned"], null) == "true",
-        try(one([
-          for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement :
-          statement.Condition.StringEqualsIfExists if try(statement.Sid, null) == "Ec2CreateTagsOnManagedResources"
-          ])["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f",
+          statement.Condition.Null if try(statement.Sid, null) == "Ec2DeleteTagsExceptProtectedTags"
+          ])["aws:TagKeys"], null) == "false",
+        length([
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement : statement
+          if try(statement.Sid, null) == "DenyDeleteTagsWhenTagKeysAbsent" &&
+          try(statement.Effect, null) == "Deny" &&
+          contains(try(tolist(statement.Action), [statement.Action]), "ec2:DeleteTags") &&
+          try(statement.Condition.StringEquals["aws:ResourceTag/AgentName"], null) == name &&
+          try(statement.Condition.StringEquals["aws:ResourceTag/ManagedBy"], null) == "superblocks-app-database-lifecycle" &&
+          try(statement.Condition.StringEquals["aws:ResourceTag/Vpc"], null) == var.agents[name].vpc_id &&
+          try(statement.Condition.Null["aws:TagKeys"], null) == "true"
+        ]) == 1,
       ])
     ])
-    error_message = "When the worker writes ownership tags via AddTags/CreateTags, IAM must require the canonical values (StringEqualsIfExists)."
+    error_message = "EC2 DeleteTags must Deny the delete-all request (missing aws:TagKeys) and the Allow must require TagKeys to be present."
+  }
+
+  # Every AddTags/CreateTags/TagResource Allow that can write ownership keys must
+  # require the canonical values when those keys appear in the request. Checking
+  # only one Sid leaves overlapping Allows that IAM ORs as a bypass.
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue(flatten([
+        [
+          for statement in concat(
+            jsondecode(aws_iam_policy.lifecycle_worker_rds_provisioning[name].policy).Statement,
+            jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement,
+            ) : (
+            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true" &&
+            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
+            ) if contains(try(tolist(statement.Action), [statement.Action]), "rds:AddTagsToResource")
+        ],
+        [
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement : (
+            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true" &&
+            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
+            ) if contains(try(tolist(statement.Action), [statement.Action]), "ec2:CreateTags")
+        ],
+        [
+          for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability[name].policy).Statement : (
+            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true" &&
+            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
+            ) if contains(try(tolist(statement.Action), [statement.Action]), "logs:TagResource")
+        ],
+      ]))
+    ])
+    error_message = "Every AddTags/CreateTags/TagResource Allow must require canonical ownership values via StringEqualsIfExists — overlapping Allows must not bypass the check."
   }
 }

--- a/modules/app-db-prereqs/tests/connector_policy.tftest.hcl
+++ b/modules/app-db-prereqs/tests/connector_policy.tftest.hcl
@@ -101,7 +101,76 @@ run "the_tags_output_matches_what_the_module_stamps" {
   }
 
   assert {
-    condition     = output.tags == { Environment = "production", ManagedBy = "superblocks-app-database-lifecycle" }
-    error_message = "The tags output must merge ManagedBy over the caller's tags."
+    condition = output.tags == {
+      "Environment"       = "production"
+      "ManagedBy"         = "superblocks-app-database-lifecycle"
+      "aws-apn-id"        = "pc:ctelqp437y3cvjkv5rv0z2w4f"
+      "superblocks:owned" = "true"
+    }
+    error_message = "The tags output must merge ManagedBy and the ownership pair over the caller's tags."
+  }
+}
+
+# Ownership and AWS Partner Network attribution is mandatory on every resource
+# Superblocks creates in a customer account, so a caller must not be able to
+# drop or reassign either key by passing its own value.
+run "ownership_tags_cannot_be_overridden_by_the_caller" {
+  command = plan
+
+  variables {
+    tags = {
+      "aws-apn-id"        = "pc:someoneelse"
+      "superblocks:owned" = "false"
+    }
+  }
+
+  assert {
+    condition = output.tags == {
+      "ManagedBy"         = "superblocks-app-database-lifecycle"
+      "aws-apn-id"        = "pc:ctelqp437y3cvjkv5rv0z2w4f"
+      "superblocks:owned" = "true"
+    }
+    error_message = "The module must override caller-supplied ownership tags with its own values."
+  }
+}
+
+# Every taggable resource this module creates carries the tags — an untagged IAM
+# policy or bucket is invisible to ownership and APN reporting.
+run "every_taggable_resource_carries_the_tags" {
+  command = plan
+
+  assert {
+    condition = alltrue(flatten([
+      for name in keys(var.agents) : [
+        for tags in [
+          aws_iam_policy.connector[name].tags,
+          aws_iam_policy.lifecycle_worker_assume_connector[name].tags,
+          aws_iam_policy.lifecycle_worker_ec2_provisioning[name].tags,
+          aws_iam_policy.lifecycle_worker_observability[name].tags,
+          aws_iam_policy.lifecycle_worker_rds_mutation[name].tags,
+          aws_iam_policy.lifecycle_worker_rds_provisioning[name].tags,
+          aws_iam_policy.lifecycle_worker_secrets[name].tags,
+          aws_iam_policy.lifecycle_worker_state_bucket[name].tags,
+          aws_iam_role.connector[name].tags,
+          aws_iam_role.lifecycle_worker[name].tags,
+          ] : [
+          tags["superblocks:owned"] == "true",
+          tags["aws-apn-id"] == "pc:ctelqp437y3cvjkv5rv0z2w4f",
+          tags["ManagedBy"] == "superblocks-app-database-lifecycle",
+        ]
+      ]
+    ]))
+    error_message = "Every IAM role and policy this module creates must carry the ownership pair and ManagedBy."
+  }
+
+  assert {
+    condition = alltrue([
+      for tags in [aws_iam_role.enhanced_monitoring[0].tags, aws_s3_bucket.tofu_state.tags] : (
+        tags["superblocks:owned"] == "true" &&
+        tags["aws-apn-id"] == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
+        tags["ManagedBy"] == "superblocks-app-database-lifecycle"
+      )
+    ])
+    error_message = "The Enhanced Monitoring role and the state bucket must carry the ownership pair and ManagedBy."
   }
 }

--- a/modules/app-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/app-db-prereqs/tests/observability.tftest.hcl
@@ -111,7 +111,6 @@ run "grants_app_database_observability_permissions" {
         "logs:ListTagsForResource",
         "logs:PutRetentionPolicy",
         "logs:TagResource",
-        "logs:UntagResource",
       ] :
       contains(one([
         for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
@@ -119,6 +118,46 @@ run "grants_app_database_observability_permissions" {
       ]), action)
     ])
     error_message = "The worker must be able to manage the log groups the physical modules declare explicitly."
+  }
+
+  assert {
+    condition = !contains(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      try(tolist(statement.Action), [statement.Action]) if statement.Sid == "CloudWatchLogGroupsForAppDatabases"
+    ]), "logs:UntagResource")
+    error_message = "UntagResource must not sit in the unconditional CloudWatch allow — protected keys need Allow-with-exclusion plus Deny."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "CloudWatchUntagExceptProtectedTags"
+      ]) == "logs:UntagResource" &&
+      toset(one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Condition["ForAllValues:StringNotEquals"]["aws:TagKeys"] if statement.Sid == "CloudWatchUntagExceptProtectedTags"
+      ])) == toset(["AgentName", "ManagedBy", "Vpc", "aws-apn-id", "superblocks:owned"])
+    )
+    error_message = "CloudWatch UntagResource Allow must exclude the protected tag keys."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Effect if statement.Sid == "DenyUntagProtectedTags"
+      ]) == "Deny" &&
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "DenyUntagProtectedTags"
+      ]) == "logs:UntagResource" &&
+      toset(one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Condition["ForAnyValue:StringEquals"]["aws:TagKeys"] if statement.Sid == "DenyUntagProtectedTags"
+      ])) == toset(["AgentName", "ManagedBy", "Vpc", "aws-apn-id", "superblocks:owned"])
+    )
+    error_message = "CloudWatch must Deny untagging protected keys via DenyUntagProtectedTags."
   }
 
   assert {

--- a/modules/app-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/app-db-prereqs/tests/observability.tftest.hcl
@@ -110,7 +110,6 @@ run "grants_app_database_observability_permissions" {
         "logs:DeleteLogGroup",
         "logs:ListTagsForResource",
         "logs:PutRetentionPolicy",
-        "logs:TagResource",
       ] :
       contains(one([
         for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
@@ -126,6 +125,32 @@ run "grants_app_database_observability_permissions" {
       try(tolist(statement.Action), [statement.Action]) if statement.Sid == "CloudWatchLogGroupsForAppDatabases"
     ]), "logs:UntagResource")
     error_message = "UntagResource must not sit in the unconditional CloudWatch allow — protected keys need Allow-with-exclusion plus Deny."
+  }
+
+  assert {
+    condition = !contains(one([
+      for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+      try(tolist(statement.Action), [statement.Action]) if statement.Sid == "CloudWatchLogGroupsForAppDatabases"
+    ]), "logs:TagResource")
+    error_message = "TagResource must not sit in the unconditional CloudWatch allow — ownership request-tag values need StringEqualsIfExists."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Action if statement.Sid == "CloudWatchTagResourceWithCanonicalOwnership"
+      ]) == "logs:TagResource" &&
+      try(one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Condition.StringEqualsIfExists if statement.Sid == "CloudWatchTagResourceWithCanonicalOwnership"
+        ])["aws:RequestTag/superblocks:owned"], null) == "true" &&
+      try(one([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
+        statement.Condition.StringEqualsIfExists if statement.Sid == "CloudWatchTagResourceWithCanonicalOwnership"
+        ])["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
+    )
+    error_message = "CloudWatch TagResource Allow must require canonical ownership values via StringEqualsIfExists."
   }
 
   assert {

--- a/modules/app-db-prereqs/variables.tf
+++ b/modules/app-db-prereqs/variables.tf
@@ -125,5 +125,5 @@ variable "existing_monitoring_role_arn" {
 variable "tags" {
   type        = map(string)
   default     = {}
-  description = "Additional tags to apply to all resources created by this module. Do not set ManagedBy — the module always enforces ManagedBy = \"superblocks-app-database-lifecycle\", which is required for IAM conditions that scope the lifecycle worker's blast radius."
+  description = "Additional tags to apply to all resources created by this module. Three keys are reserved and always overridden: ManagedBy = \"superblocks-app-database-lifecycle\", which the IAM conditions that scope the lifecycle worker's blast radius depend on, plus superblocks:owned = \"true\" and aws-apn-id, the ownership and AWS Partner Network attribution required on every Superblocks-created resource."
 }

--- a/modules/app-db/main.tf
+++ b/modules/app-db/main.tf
@@ -41,9 +41,24 @@ locals {
     use_lockfile = true
   }
 
+  # Ownership and AWS Partner Network attribution, mandatory on every AWS
+  # resource Superblocks creates in a customer account. The databases the worker
+  # provisions at runtime inherit no provider default_tags — the worker runs tofu
+  # against the module inputs rendered here — so the pair is merged over the
+  # caller's tags rather than defaulted into them. app-db-prereqs stamps the same
+  # two keys on the prerequisite resources and denies the worker permission to
+  # strip them afterwards.
+  ownership_tags = {
+    "aws-apn-id"        = "pc:ctelqp437y3cvjkv5rv0z2w4f"
+    "superblocks:owned" = "true"
+  }
+
   # Physical inputs both modules accept. publicly_accessible is always false —
   # the lifecycle worker IAM policy enforces this at create time regardless of
   # module input.
+  #
+  # ManagedBy, AgentName, and Vpc are absent here on purpose: the worker stamps
+  # those per resource, and its IAM requires them on every create.
   physical_inputs_shared = {
     allowed_cidr_blocks       = var.physical_module_inputs.allowed_cidr_blocks
     backup_retention_period   = var.physical_module_inputs.backup_retention_period
@@ -55,7 +70,7 @@ locals {
     skip_final_snapshot       = var.physical_module_inputs.skip_final_snapshot
     source_security_group_ids = var.physical_module_inputs.source_security_group_ids
     subnet_ids                = var.physical_module_inputs.subnet_ids
-    tags                      = var.physical_module_inputs.tags
+    tags                      = merge(var.physical_module_inputs.tags, local.ownership_tags)
     vpc_id                    = var.physical_module_inputs.vpc_id
   }
 

--- a/modules/app-db/tests/physical_module.tftest.hcl
+++ b/modules/app-db/tests/physical_module.tftest.hcl
@@ -310,6 +310,46 @@ run "agent_name_rejects_underscores" {
   expect_failures = [var.agent_name]
 }
 
+# Databases the worker provisions at runtime inherit no provider default_tags,
+# so the ownership pair has to travel in the rendered module inputs — for every
+# OPA, whether or not the caller passes tags of its own.
+run "ownership_tags_reach_the_physical_module_without_the_caller_asking" {
+  command = plan
+
+  assert {
+    condition = jsonencode(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.tags) == jsonencode({ "aws-apn-id" = "pc:ctelqp437y3cvjkv5rv0z2w4f", "superblocks:owned" = "true" })
+    error_message = "Every OPA must tag the databases it provisions with the ownership pair, even when the caller passes no tags."
+  }
+}
+
+run "caller_tags_are_kept_but_cannot_override_the_ownership_pair" {
+  command = plan
+
+  variables {
+    physical_module_inputs = {
+      monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
+      subnet_ids          = ["subnet-0000000000000001", "subnet-0000000000000002"]
+      vpc_id              = "vpc-0123456789abcdef0"
+      tags = {
+        "Environment"       = "production"
+        "aws-apn-id"        = "pc:someoneelse"
+        "superblocks:owned" = "false"
+      }
+    }
+  }
+
+  assert {
+    condition = jsonencode(jsondecode([
+      for env in output.ecs_env_vars : env.value
+      if env.name == "SUPERBLOCKS_DATABASE_LIFECYCLE_CONFIG"
+    ][0]).operations.ensure_physical_database_instance.terraform.moduleSelectors.postgres.inputs.tags) == jsonencode({ "Environment" = "production", "aws-apn-id" = "pc:ctelqp437y3cvjkv5rv0z2w4f", "superblocks:owned" = "true" })
+    error_message = "Caller tags must survive, but the ownership pair must win over caller-supplied values."
+  }
+}
+
 run "multi_az_alone_cannot_select_rds" {
   command = plan
 

--- a/modules/app-db/variables.tf
+++ b/modules/app-db/variables.tf
@@ -107,6 +107,8 @@ variable "physical_module_inputs" {
 
     publicly_accessible is always false and is not configurable — the lifecycle worker IAM policy enforces it regardless.
 
+    `tags` are applied to every database, security group, and parameter group the OPA provisions. The ownership pair `superblocks:owned = "true"` and `aws-apn-id` is always merged over whatever you pass, and the lifecycle worker adds the `ManagedBy`, `AgentName`, and `Vpc` tags its own IAM conditions require.
+
     Enhanced Monitoring is on at a 60 second interval, which RDS only accepts alongside an IAM role it can assume. Pass the prerequisite stack's `enhanced_monitoring_role_arn` output as `monitoring_role_arn`, or set `monitoring_interval = 0` to turn Enhanced Monitoring off.
   EOT
 


### PR DESCRIPTION
Every AWS resource Superblocks creates in a customer account must carry `superblocks:owned=true` and `aws-apn-id=pc:ctelqp437y3cvjkv5rv0z2w4f`. Neither tag reached the app database resources today: `app-db-prereqs` stamped only `ManagedBy`, several of its IAM policies were untagged entirely, and the Aurora/RDS resources the lifecycle worker provisions at runtime inherit no provider `default_tags` — so only stacks wiring Terragrunt `default_tags` got them.

- `app-db-prereqs` merges the pair over `var.tags` (callers can't drop or reassign it), tags all eight IAM policies it creates, and adds both keys to the tag keys the worker is denied permission to remove — alongside the existing `AgentName`/`ManagedBy`/`Vpc` protection.
- `app-db` merges the same pair over `physical_module_inputs.tags`, so every OPA tags its clusters, security groups, and parameter groups, whatever the caller passes.

The `ManagedBy`/`AgentName`/`Vpc` conditions that scope the worker's blast radius are untouched. The worker IAM policy already allows `AddTagsToResource` / equivalent tag adds, so a later OpenTofu apply that includes the pair in `inputs.tags` can add them to resources it manages — but this PR does **not** backfill existing fleets. Prereq resources pick up the tags on the next customer `terraform apply` of `app-db-prereqs`. Runtime Aurora/RDS get them on create going forward, or only if something later re-applies that physical state with the new tags; idle clusters are not walked automatically.

Verified with `tofu test` in both modules (28 pass in `app-db`, 18 in `app-db-prereqs`), covering: caller values for either key being overridden, every taggable prereq resource carrying the pair, and the rendered runtime module inputs carrying it with and without caller tags.

Per the cross-repo sync note in AGENTS.md, the Azure and GCP OPA modules need the equivalent change; not in this PR. EKS/Helm does not inject the pair by default today — see docs-v2#202 and the orchestrator follow-up noted on ENG-5527.