### PR TITLE
feat(app-db-prereqs): split name_prefix into iam and s3 prefixes (ENG-5526)

### DIFF
--- a/examples/app-db-eks/main.tf
+++ b/examples/app-db-eks/main.tf
@@ -64,15 +64,18 @@ module "app_db_prereqs" {
     # }
   }
 
-  # Optional: override the default resource name prefix ("sb-app-db").
-  # name_prefix = "acme-app-db"
+  # Optional: override IAM and S3 name prefixes independently (both default
+  # to "sb-app-db") when your organization requires different naming for
+  # IAM roles/policies vs the OpenTofu state bucket.
+  # iam_name_prefix = "acme-app-db"
+  # s3_name_prefix  = "acme-state"
 
   # Optional: customer-managed KMS key for the OpenTofu state bucket.
   # kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/mrk-..."
 
   # Optional: reuse an account-level Enhanced Monitoring role created by a
   # prior regional apply of this module. The role name is account-scoped
-  # (<name_prefix>-enhanced-monitoring), so a second region must pass the ARN
+  # (<iam_name_prefix>-enhanced-monitoring), so a second region must pass the ARN
   # from the first instead of creating another copy.
   # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
 

--- a/examples/app-db-fargate/main.tf
+++ b/examples/app-db-fargate/main.tf
@@ -82,11 +82,11 @@ module "app_db_prereqs" {
     # }
   }
 
-  # Optional: override the default resource name prefix ("sb-app-db").
-  # IAM roles are named <name_prefix>-<agent_name>-*; the S3 state bucket is
-  # named <name_prefix>-<region>-<account_id>.
-  # Max 16 characters. Only needed when your org enforces a naming convention.
-  # name_prefix = "acme-app-db"
+  # Optional: override IAM and S3 name prefixes independently (both default
+  # to "sb-app-db") when your organization requires different naming for
+  # IAM roles/policies vs the OpenTofu state bucket. Max 16 characters each.
+  # iam_name_prefix = "acme-app-db"
+  # s3_name_prefix  = "acme-state"
 
   # Optional: customer-managed KMS key for the OpenTofu state bucket.
   # When omitted, the bucket uses AWS account-default encryption (SSE-S3) and
@@ -95,7 +95,7 @@ module "app_db_prereqs" {
 
   # Optional: reuse an account-level Enhanced Monitoring role created by a
   # prior regional apply of this module. The role name is account-scoped
-  # (<name_prefix>-enhanced-monitoring), so a second region must pass the ARN
+  # (<iam_name_prefix>-enhanced-monitoring), so a second region must pass the ARN
   # from the first instead of creating another copy.
   # existing_monitoring_role_arn = "arn:aws:iam::123456789012:role/sb-app-db-enhanced-monitoring"
 

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -243,7 +243,7 @@ locals {
 resource "aws_iam_role" "lifecycle_worker" {
   for_each = { for k, agent in var.agents : k => agent if agent.existing_role_name == null }
 
-  name               = "${var.name_prefix}-${each.key}-lifecycle-worker-${var.region}"
+  name               = "${var.iam_name_prefix}-${each.key}-lifecycle-worker-${var.region}"
   assume_role_policy = local.lifecycle_worker_assume_role_policies[each.key]
 
   tags = local.tags
@@ -255,7 +255,7 @@ resource "aws_iam_role" "lifecycle_worker" {
 resource "aws_iam_policy" "lifecycle_worker_assume_connector" {
   for_each = var.agents
 
-  name        = "${var.name_prefix}-${each.key}-assume-connector"
+  name        = "${var.iam_name_prefix}-${each.key}-assume-connector"
   description = "Allows the ${each.key} lifecycle worker to assume its connector role for RDS IAM authentication."
 
   policy = jsonencode({
@@ -289,7 +289,7 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_assume_connector" {
 resource "aws_iam_policy" "lifecycle_worker_state_bucket" {
   for_each = var.agents
 
-  name        = "${var.name_prefix}-${each.key}-state-bucket-${var.region}"
+  name        = "${var.iam_name_prefix}-${each.key}-state-bucket-${var.region}"
   description = "Allows the ${each.key} lifecycle worker to read and write OpenTofu state under ${local.agent_state_key_prefixes[each.key]}/ in the shared S3 bucket."
 
   policy = jsonencode({
@@ -362,7 +362,7 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_state_bucket" {
 resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
   for_each = var.agents
 
-  name        = "${var.name_prefix}-${each.key}-rds-provisioning-${var.region}"
+  name        = "${var.iam_name_prefix}-${each.key}-rds-provisioning-${var.region}"
   description = "Allows the ${each.key} lifecycle worker to describe and provision RDS/Aurora instances and clusters."
 
   policy = jsonencode({
@@ -581,7 +581,7 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_provisioning" {
 resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
   for_each = var.agents
 
-  name        = "${var.name_prefix}-${each.key}-rds-mutation-${var.region}"
+  name        = "${var.iam_name_prefix}-${each.key}-rds-mutation-${var.region}"
   description = "Allows the ${each.key} lifecycle worker to modify, delete, snapshot, and tag RDS/Aurora resources it owns."
 
   policy = jsonencode({
@@ -784,7 +784,7 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_rds_mutation" {
 resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
   for_each = var.agents
 
-  name        = "${var.name_prefix}-${each.key}-ec2-provisioning-${var.region}"
+  name        = "${var.iam_name_prefix}-${each.key}-ec2-provisioning-${var.region}"
   description = "Allows the ${each.key} lifecycle worker to describe VPCs and manage security groups it created."
 
   policy = jsonencode({
@@ -979,7 +979,7 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_ec2_provisioning" {
 resource "aws_iam_policy" "lifecycle_worker_secrets" {
   for_each = var.agents
 
-  name        = "${var.name_prefix}-${each.key}-secrets-${var.region}"
+  name        = "${var.iam_name_prefix}-${each.key}-secrets-${var.region}"
   description = "Allows the ${each.key} lifecycle worker to manage RDS master credentials and read RDS-managed secrets."
 
   policy = jsonencode({
@@ -1078,7 +1078,7 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_secrets" {
 resource "aws_iam_policy" "lifecycle_worker_observability" {
   for_each = var.agents
 
-  name        = "${var.name_prefix}-${each.key}-observability-${var.region}"
+  name        = "${var.iam_name_prefix}-${each.key}-observability-${var.region}"
   description = "Allows the ${each.key} lifecycle worker to manage App Database CloudWatch log groups and pass the shared Enhanced Monitoring role."
 
   policy = jsonencode({
@@ -1190,7 +1190,7 @@ resource "aws_iam_role_policy_attachment" "lifecycle_worker_observability" {
 resource "aws_iam_role" "enhanced_monitoring" {
   count = local.create_monitoring_role ? 1 : 0
 
-  name = "${var.name_prefix}-enhanced-monitoring"
+  name = "${var.iam_name_prefix}-enhanced-monitoring"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -1299,10 +1299,10 @@ resource "aws_iam_role_policy_attachment" "connector" {
 # Always created — no conditional logic needed since all agents are declared
 # in this single module call.
 #
-# Bucket name format: <name_prefix>-<region>-<account_id>
+# Bucket name format: <s3_name_prefix>-<region>-<account_id>
 ####################################################################
 resource "aws_s3_bucket" "tofu_state" {
-  bucket = "${var.name_prefix}-${var.region}-${data.aws_caller_identity.current.account_id}"
+  bucket = "${var.s3_name_prefix}-${var.region}-${data.aws_caller_identity.current.account_id}"
 
   tags = local.tags
 

--- a/modules/app-db-prereqs/variables.tf
+++ b/modules/app-db-prereqs/variables.tf
@@ -94,14 +94,25 @@ variable "agents" {
   }
 }
 
-variable "name_prefix" {
+variable "iam_name_prefix" {
   type        = string
   default     = "sb-app-db"
-  description = "Prefix applied to all IAM roles, policies, and the S3 state bucket created by this module. Defaults to 'sb-app-db'. Override when your organization requires a specific naming convention. Max 16 characters (combined with region (≤14) and account ID (12) the bucket name stays under S3's 63-character limit)."
+  description = "Prefix applied to IAM roles and policies created by this module. Defaults to 'sb-app-db'. Max 16 lowercase alphanumeric characters or hyphens."
 
   validation {
-    condition     = can(regex("^[a-z0-9][a-z0-9-]{0,14}[a-z0-9]$", var.name_prefix))
-    error_message = "Variable name_prefix must be 2-16 lowercase alphanumeric characters or hyphens, and must not start or end with a hyphen."
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$", var.iam_name_prefix))
+    error_message = "Variable iam_name_prefix must be 1-16 lowercase alphanumeric characters or hyphens, and must not start or end with a hyphen."
+  }
+}
+
+variable "s3_name_prefix" {
+  type        = string
+  default     = "sb-app-db"
+  description = "Prefix applied to the OpenTofu state bucket created by this module. Defaults to 'sb-app-db'. Max 16 lowercase alphanumeric characters or hyphens."
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$", var.s3_name_prefix))
+    error_message = "Variable s3_name_prefix must be 1-16 lowercase alphanumeric characters or hyphens, and must not start or end with a hyphen."
   }
 }
 
@@ -114,7 +125,7 @@ variable "kms_key_arn" {
 variable "existing_monitoring_role_arn" {
   type        = string
   default     = null
-  description = "ARN of an existing account-level RDS Enhanced Monitoring role. When null, the module creates <name_prefix>-enhanced-monitoring. Set this in additional regions so every worker reuses one shared role instead of creating a second copy. The physical database modules take this ARN as monitoring_role_arn; the worker is granted iam:PassRole on it and nothing else. Setting this on a deployment that previously created the role destroys that role: any database still configured with the old ARN loses Enhanced Monitoring until the physical modules are re-pointed at the role you supply here, so re-point them first."
+  description = "ARN of an existing account-level RDS Enhanced Monitoring role. When null, the module creates <iam_name_prefix>-enhanced-monitoring. Set this in additional regions so every worker reuses one shared role instead of creating a second copy. The physical database modules take this ARN as monitoring_role_arn; the worker is granted iam:PassRole on it and nothing else. Setting this on a deployment that previously created the role destroys that role: any database still configured with the old ARN loses Enhanced Monitoring until the physical modules are re-pointed at the role you supply here, so re-point them first."
 
   validation {
     condition     = var.existing_monitoring_role_arn == null || can(regex("^arn:aws:iam::[0-9]{12}:role/([A-Za-z0-9+=,.@_-]+/)*[A-Za-z0-9+=,.@_-]+$", var.existing_monitoring_role_arn))


### PR DESCRIPTION
## Summary

`app-db-prereqs` had a single `name_prefix` variable that named **both** the IAM roles/policies **and** the OpenTofu state bucket. That forces one naming convention across two resource types whose constraints are unrelated, so a caller whose org requires different naming for IAM vs S3 had no way to satisfy both.

This splits it into two independent variables:

| Variable | Default | Controls |
| --- | --- | --- |
| `iam_name_prefix` | `sb-app-db` | Lifecycle worker roles/policies, enhanced-monitoring role |
| `s3_name_prefix` | `sb-app-db` | OpenTofu state bucket |

Both default to `sb-app-db` — the same value the old `name_prefix` defaulted to — so callers on defaults produce byte-identical resource names. No rename, no state bucket recreation.

`name_prefix` is removed rather than kept as a deprecated fallback, since this module has not shipped to customers yet. Callers that explicitly set `name_prefix` switch to the two new variables.

## Unchanged

- The connector role keeps its reserved, hardcoded name `superblocks-app-db-connector-<agent>` and is not driven by either prefix.
- Prefix validation allows 1-16 lowercase alphanumeric characters or hyphens, with no leading/trailing hyphen (same intent as before, but 1-character prefixes are now valid).

## Test plan

- [ ] Examples still apply with defaults (`sb-app-db` for both prefixes).
- [ ] Overriding `iam_name_prefix` and `s3_name_prefix` independently names IAM and the state bucket as expected.
- [ ] Connector role name remains `superblocks-app-db-connector-<agent>` regardless of either prefix.