### PR TITLE
feat(app-db-prereqs): allow create-time tags on security-group rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,22 @@
 `aws-apn-id=pc:ctelqp437y3cvjkv5rv0z2w4f` on resources they create (or render
 into runtime physical-module inputs). The lifecycle worker IAM policies also
 protect those keys from removal (and require the canonical values when the
-worker writes them via tag APIs).
+worker writes them via tag APIs). Runtime App DB security-group rules use the
+taggable `aws_vpc_security_group_*_rule` resources, and create-time tagging is
+authorized for `AuthorizeSecurityGroupIngress` / `AuthorizeSecurityGroupEgress`
+as well as `CreateSecurityGroup`.
 
 **Upgrade together.** Once `app-db-prereqs` protects the ownership keys, do not
 pin `app-db` to an older release that omits them from `physical_module_inputs.tags`.
 That skew fails closed on later physical applies: OpenTofu tries to remove the
-tags, and `rds:RemoveTagsFromResource` / `ec2:DeleteTags` are denied.
+tags, and `rds:RemoveTagsFromResource` / `ec2:DeleteTags` are denied. Also pin a
+`terraform-superblocks-databases` release that uses the taggable VPC security-group
+rule resources so runtime applies can stamp ownership tags on every rule.
 
 Tags land on new creates and on the next apply that touches that state. There
-is no automatic backfill of idle fleets.
+is no automatic backfill of idle fleets. Migrating an existing physical state
+from legacy `aws_security_group_rule` to `aws_vpc_security_group_*_rule` replaces
+the rule objects (new `sgr-*` IDs).
 
 `existing_role_name` still attaches policies to a customer-provided lifecycle
 role; this module does **not** tag that existing role. Ownership tags apply to

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -842,6 +842,12 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           }
         },
         {
+          # TagSpecifications on CreateSecurityGroup and on
+          # AuthorizeSecurityGroupIngress/Egress both evaluate CreateTags with
+          # ec2:CreateAction set to the mutating API. Without the authorize
+          # actions here, taggable aws_vpc_security_group_*_rule resources fail
+          # create-time tagging (the managed-resource Sid requires tags that do
+          # not exist yet on a brand-new rule).
           Sid    = "Ec2CreateTagsOnCreateSecurityGroup"
           Effect = "Allow"
           Action = ["ec2:CreateTags"]
@@ -854,7 +860,11 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
               "aws:RequestTag/AgentName" = each.key
               "aws:RequestTag/ManagedBy" = local.managed_by_tag
               "aws:RequestTag/Vpc"       = each.value.vpc_id
-              "ec2:CreateAction"         = "CreateSecurityGroup"
+              "ec2:CreateAction" = [
+                "AuthorizeSecurityGroupEgress",
+                "AuthorizeSecurityGroupIngress",
+                "CreateSecurityGroup",
+              ]
             }
             # Same overlapping-Allow bypass as RdsTagOnCreate: without this,
             # CreateTags on create can write non-canonical ownership values

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -214,4 +214,20 @@ run "lifecycle_policies_require_matching_agent_name" {
     ])
     error_message = "Every AddTags/CreateTags/TagResource Allow must require canonical ownership values via StringEqualsIfExists — overlapping Allows must not bypass the check."
   }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : alltrue([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement : (
+          statement.Sid != "Ec2CreateTagsOnCreateSecurityGroup" ||
+          toset(try(tolist(statement.Condition.StringEquals["ec2:CreateAction"]), [statement.Condition.StringEquals["ec2:CreateAction"]])) == toset([
+            "AuthorizeSecurityGroupEgress",
+            "AuthorizeSecurityGroupIngress",
+            "CreateSecurityGroup",
+          ])
+        )
+      ])
+    ])
+    error_message = "Create-time EC2 tagging must authorize security-group and security-group-rule creates (CreateSecurityGroup plus AuthorizeSecurityGroupIngress/Egress)."
+  }
 }

--- a/modules/app-db/variables.tf
+++ b/modules/app-db/variables.tf
@@ -107,7 +107,7 @@ variable "physical_module_inputs" {
 
     publicly_accessible is always false and is not configurable — the lifecycle worker IAM policy enforces it regardless.
 
-    `tags` are applied to every database, security group, and parameter group the OPA provisions. The ownership pair `superblocks:owned = "true"` and `aws-apn-id` is always merged over whatever you pass, and the lifecycle worker adds the `ManagedBy`, `AgentName`, and `Vpc` tags its own IAM conditions require.
+    `tags` are applied to every database, security group, security-group rule, and parameter group the OPA provisions. The ownership pair `superblocks:owned = "true"` and `aws-apn-id` is always merged over whatever you pass, and the lifecycle worker adds the `ManagedBy`, `AgentName`, and `Vpc` tags its own IAM conditions require.
 
     Enhanced Monitoring is on at a 60 second interval, which RDS only accepts alongside an IAM role it can assume. Pass the prerequisite stack's `enhanced_monitoring_role_arn` output as `monitoring_role_arn`, or set `monitoring_interval = 0` to turn Enhanced Monitoring off.
   EOT


### PR DESCRIPTION
## Summary
- Expand `Ec2CreateTagsOnCreateSecurityGroup` so create-time `CreateTags` is allowed for `AuthorizeSecurityGroupIngress` / `AuthorizeSecurityGroupEgress` (in addition to `CreateSecurityGroup`)
- Restore App DB ownership-contract wording to include security-group rules
- Document the upgrade coupling with the taggable VPC rule resources in `terraform-superblocks-databases`

Pairs with the physical-module migration in `terraform-superblocks-databases` for [ENG-5557](https://linear.app/superblocks/issue/ENG-5557/migrate-app-db-security-group-rules-to-taggable-aws-vpc-security-group). Without this IAM change, taggable rule creates fail create-time tagging because the managed-resource Sid requires tags that do not exist yet on a brand-new rule.

## Test plan
- [x] `tofu test` in `modules/app-db-prereqs` (18 passed)
- [x] `tofu test` in `modules/app-db` (28 passed)
- [ ] CI checks green


Made with [Cursor](https://cursor.com)