### PR TITLE
docs: record v1.5.2 changelog without internal upgrade notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,23 @@
 
 ## Unreleased
 
-### Breaking / upgrade notes
+## v1.5.2
 
-#### App Database ownership and APN tags (`app-db`, `app-db-prereqs`)
+### App DB: ownership and APN tags
 
-`app-db-prereqs` and `app-db` now always stamp `superblocks:owned=true` and
-`aws-apn-id=pc:ctelqp437y3cvjkv5rv0z2w4f` on resources they create (or render
-into runtime physical-module inputs). The lifecycle worker IAM policies also
-protect those keys from removal (and require the canonical values when the
-worker writes them via tag APIs). Runtime App DB security-group rules use the
-taggable `aws_vpc_security_group_*_rule` resources, and create-time tagging is
-authorized for `AuthorizeSecurityGroupIngress` / `AuthorizeSecurityGroupEgress`
-as well as `CreateSecurityGroup`.
+`app-db-prereqs` and `app-db` always stamp `superblocks:owned=true` and
+`aws-apn-id=pc:ctelqp437y3cvjkv5rv0z2w4f` on resources they create; lifecycle-worker
+IAM protects those keys from removal.
+([#66](https://github.com/superblocksteam/terraform-aws-superblocks/pull/66))
 
-**Upgrade together.** Once `app-db-prereqs` protects the ownership keys, do not
-pin `app-db` to an older release that omits them from `physical_module_inputs.tags`.
-That skew fails closed on later physical applies: OpenTofu tries to remove the
-tags, and `rds:RemoveTagsFromResource` / `ec2:DeleteTags` are denied. Also pin a
-`terraform-superblocks-databases` release that uses the taggable VPC security-group
-rule resources so runtime applies can stamp ownership tags on every rule.
+### App DB prereqs: independent IAM / S3 name prefixes
 
-Tags land on new creates and on the next apply that touches that state. There
-is no automatic backfill of idle fleets. Migrating an existing physical state
-from legacy `aws_security_group_rule` to `aws_vpc_security_group_*_rule` replaces
-the rule objects (new `sgr-*` IDs).
+`name_prefix` is replaced by `iam_name_prefix` and `s3_name_prefix` (both default
+`sb-app-db`). Callers that set `name_prefix` must switch to the two new variables.
+([#67](https://github.com/superblocksteam/terraform-aws-superblocks/pull/67))
 
-`existing_role_name` still attaches policies to a customer-provided lifecycle
-role; this module does **not** tag that existing role. Ownership tags apply to
-resources this module creates (policies, connector/monitoring roles when
-created, state bucket) and to runtime App DB resources via `app-db` / Helm
-`physicalModuleTags`.
+### App DB prereqs: create-time tags on security-group rules
+
+Create-time `ec2:CreateTags` authorization now covers security-group rule creates
+(`AuthorizeSecurityGroupIngress` / `Egress`) in addition to `CreateSecurityGroup`.
+([#68](https://github.com/superblocksteam/terraform-aws-superblocks/pull/68))


### PR DESCRIPTION
## Summary
- Fold the Unreleased App DB notes into a customer-facing `## v1.5.2` section matching the [v1.5.2 release](https://github.com/superblocksteam/terraform-aws-superblocks/releases/tag/v1.5.2)
- Drop internal upgrade-together / idle-fleet / physical-module coupling guidance from the public changelog
- Include the `name_prefix` → `iam_name_prefix` / `s3_name_prefix` split that was missing from Unreleased

## Test plan
- [x] Skim `CHANGELOG.md` for public tone only
- [x] Confirm it matches the published v1.5.2 release notes

Agent-authored PR (hansmaryil / Cursor).

Made with [Cursor](https://cursor.com)