### PR TITLE
fix(app-db-prereqs): authorize tagged security-group rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### App DB prereqs: authorize tagged security-group rule creation
+
+Lifecycle workers can authorize new ingress and egress rule resources when
+their create request carries the required agent, lifecycle, VPC, and ownership
+tags. Existing security-group mutation remains scoped by resource tags.
+
 ## v1.5.2
 
 ### App DB: ownership and APN tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@
 ### App DB prereqs: authorize tagged security-group rule creation
 
 Lifecycle workers can authorize new ingress and egress rule resources when
-their create request carries the required agent, lifecycle, and VPC tags.
-Canonical ownership and APN tag values are enforced when supplied. Existing
-security-group mutation remains scoped by resource tags.
+their create request carries the required agent, lifecycle, VPC, ownership,
+and APN tags. Existing security-group mutation remains scoped by resource tags.
 
 ## v1.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### App DB prereqs: authorize tagged security-group rule creation
 
 Lifecycle workers can authorize new ingress and egress rule resources when
-their create request carries the required agent, lifecycle, VPC, and ownership
-tags. Existing security-group mutation remains scoped by resource tags.
+their create request carries the required agent, lifecycle, and VPC tags.
+Canonical ownership and APN tag values are enforced when supplied. Existing
+security-group mutation remains scoped by resource tags.
 
 ## v1.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### App DB prereqs: authorize tagged security-group rule creation
 
 Lifecycle workers can authorize new ingress and egress rule resources when
-their create request carries the required agent, lifecycle, VPC, ownership,
-and APN tags. Existing security-group mutation remains scoped by resource tags.
+their create request carries the required agent, lifecycle, and VPC tags.
+Canonical ownership and APN tag values are enforced when supplied. Existing
+security-group mutation remains scoped by resource tags.
 
 ## v1.5.2
 

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -840,6 +840,9 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
               "aws:RequestTag/ManagedBy" = local.managed_by_tag
               "aws:RequestTag/Vpc"       = each.value.vpc_id
             }
+            # Direct lifecycle configurations deployed before the ownership-tag
+            # contract may omit these tags. Preserve that compatibility while
+            # rejecting non-canonical values whenever either tag is supplied.
             StringEqualsIfExists = {
               "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
               "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -822,6 +822,31 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           }
         },
         {
+          # A taggable aws_vpc_security_group_*_rule create authorizes both the
+          # existing security group and the new security-group-rule resource.
+          # Ec2SecurityGroupMutate covers the tagged group; the rule has no
+          # resource tags until creation, so authorize it from canonical
+          # request tags instead.
+          Sid    = "Ec2CreateTaggedSecurityGroupRules"
+          Effect = "Allow"
+          Action = [
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:AuthorizeSecurityGroupIngress",
+          ]
+          Resource = "${local.ec2_prefix}:security-group-rule/*"
+          Condition = {
+            StringEquals = {
+              "aws:RequestTag/AgentName" = each.key
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+            }
+            StringEqualsIfExists = {
+              "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+              "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
+            }
+          }
+        },
+        {
           Sid    = "Ec2SecurityGroupMutate"
           Effect = "Allow"
           Action = [

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -836,14 +836,9 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           Resource = "${local.ec2_prefix}:security-group-rule/*"
           Condition = {
             StringEquals = {
-              "aws:RequestTag/AgentName" = each.key
-              "aws:RequestTag/ManagedBy" = local.managed_by_tag
-              "aws:RequestTag/Vpc"       = each.value.vpc_id
-            }
-            # Direct lifecycle configurations deployed before the ownership-tag
-            # contract may omit these tags. Preserve that compatibility while
-            # rejecting non-canonical values whenever either tag is supplied.
-            StringEqualsIfExists = {
+              "aws:RequestTag/AgentName"         = each.key
+              "aws:RequestTag/ManagedBy"         = local.managed_by_tag
+              "aws:RequestTag/Vpc"               = each.value.vpc_id
               "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
               "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
             }

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -836,9 +836,14 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           Resource = "${local.ec2_prefix}:security-group-rule/*"
           Condition = {
             StringEquals = {
-              "aws:RequestTag/AgentName"         = each.key
-              "aws:RequestTag/ManagedBy"         = local.managed_by_tag
-              "aws:RequestTag/Vpc"               = each.value.vpc_id
+              "aws:RequestTag/AgentName" = each.key
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
+            }
+            # Direct lifecycle configurations deployed before the ownership-tag
+            # contract may omit these tags. Preserve that compatibility while
+            # rejecting non-canonical values whenever either tag is supplied.
+            StringEqualsIfExists = {
               "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
               "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
             }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -251,10 +251,10 @@ run "lifecycle_policies_require_matching_agent_name" {
         try(statement.Condition.StringEquals["aws:RequestTag/AgentName"], null) == name &&
         try(statement.Condition.StringEquals["aws:RequestTag/ManagedBy"], null) == "superblocks-app-database-lifecycle" &&
         try(statement.Condition.StringEquals["aws:RequestTag/Vpc"], null) == var.agents[name].vpc_id &&
-        try(statement.Condition.StringEquals["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
-        try(statement.Condition.StringEquals["aws:RequestTag/superblocks:owned"], null) == "true"
+        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
+        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true"
       ]) == 1
     ])
-    error_message = "Security-group rule creates must require every canonical request tag when authorizing the new rule ARN; resource tags do not exist yet."
+    error_message = "Security-group rule creates must authorize the new rule ARN from canonical request tags; resource tags do not exist yet."
   }
 }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -230,4 +230,25 @@ run "lifecycle_policies_require_matching_agent_name" {
     ])
     error_message = "Create-time EC2 tagging must authorize security-group and security-group-rule creates (CreateSecurityGroup plus AuthorizeSecurityGroupIngress/Egress)."
   }
+
+  assert {
+    condition = alltrue([
+      for name in keys(var.agents) : length([
+        for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement : statement
+        if try(statement.Sid, null) == "Ec2CreateTaggedSecurityGroupRules" &&
+        try(statement.Effect, null) == "Allow" &&
+        toset(try(tolist(statement.Action), [statement.Action])) == toset([
+          "ec2:AuthorizeSecurityGroupEgress",
+          "ec2:AuthorizeSecurityGroupIngress",
+        ]) &&
+        try(statement.Resource, null) == "arn:aws:ec2:us-east-1:123456789012:security-group-rule/*" &&
+        try(statement.Condition.StringEquals["aws:RequestTag/AgentName"], null) == name &&
+        try(statement.Condition.StringEquals["aws:RequestTag/ManagedBy"], null) == "superblocks-app-database-lifecycle" &&
+        try(statement.Condition.StringEquals["aws:RequestTag/Vpc"], null) == var.agents[name].vpc_id &&
+        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
+        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true"
+      ]) == 1
+    ])
+    error_message = "Security-group rule creates must authorize the new rule ARN from canonical request tags; resource tags do not exist yet."
+  }
 }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -251,10 +251,10 @@ run "lifecycle_policies_require_matching_agent_name" {
         try(statement.Condition.StringEquals["aws:RequestTag/AgentName"], null) == name &&
         try(statement.Condition.StringEquals["aws:RequestTag/ManagedBy"], null) == "superblocks-app-database-lifecycle" &&
         try(statement.Condition.StringEquals["aws:RequestTag/Vpc"], null) == var.agents[name].vpc_id &&
-        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
-        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true"
+        try(statement.Condition.StringEquals["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
+        try(statement.Condition.StringEquals["aws:RequestTag/superblocks:owned"], null) == "true"
       ]) == 1
     ])
-    error_message = "Security-group rule creates must authorize the new rule ARN from canonical request tags; resource tags do not exist yet."
+    error_message = "Security-group rule creates must require every canonical request tag when authorizing the new rule ARN; resource tags do not exist yet."
   }
 }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -220,15 +220,21 @@ run "lifecycle_policies_require_matching_agent_name" {
       for name in keys(var.agents) : alltrue([
         for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement : (
           statement.Sid != "Ec2CreateTagsOnCreateSecurityGroup" ||
-          toset(try(tolist(statement.Condition.StringEquals["ec2:CreateAction"]), [statement.Condition.StringEquals["ec2:CreateAction"]])) == toset([
-            "AuthorizeSecurityGroupEgress",
-            "AuthorizeSecurityGroupIngress",
-            "CreateSecurityGroup",
-          ])
+          (
+            toset(try(tolist(statement.Resource), [statement.Resource])) == toset([
+              "arn:aws:ec2:us-east-1:123456789012:security-group-rule/*",
+              "arn:aws:ec2:us-east-1:123456789012:security-group/*",
+            ]) &&
+            toset(try(tolist(statement.Condition.StringEquals["ec2:CreateAction"]), [statement.Condition.StringEquals["ec2:CreateAction"]])) == toset([
+              "AuthorizeSecurityGroupEgress",
+              "AuthorizeSecurityGroupIngress",
+              "CreateSecurityGroup",
+            ])
+          )
         )
       ])
     ])
-    error_message = "Create-time EC2 tagging must authorize security-group and security-group-rule creates (CreateSecurityGroup plus AuthorizeSecurityGroupIngress/Egress)."
+    error_message = "Create-time EC2 tagging must authorize security-group and security-group-rule resources for CreateSecurityGroup plus AuthorizeSecurityGroupIngress/Egress."
   }
 
   assert {


### PR DESCRIPTION
## Summary
- authorize `AuthorizeSecurityGroupIngress` and `AuthorizeSecurityGroupEgress` on newly created `security-group-rule/*` resources using the canonical create request tags
- retain resource-tag scoping for mutations of existing security groups
- add a regression assertion for the exact resource scope and ownership conditions

This closes the IAM gap exposed by the taggable `aws_vpc_security_group_ingress_rule` and `aws_vpc_security_group_egress_rule` resources: the new rule has request tags at authorization time, but no resource tags yet.

## Test plan
- [x] `tofu test` in `modules/app-db-prereqs` (18 passed)

Authored by a Cursor agent at David's request.

Made with [Cursor](https://cursor.com)