### PR TITLE
fix(app-db-prereqs): require canonical ownership tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-### App DB prereqs: authorize tagged security-group rule creation
+### App DB prereqs: require canonical ownership tags
 
 Lifecycle workers can authorize new ingress and egress rule resources when
 their create request carries the required agent, lifecycle, and VPC tags.
-Canonical ownership and APN tag values are enforced when supplied. Existing
+Tagging requests must include the canonical ownership and APN values. Existing
 security-group mutation remains scoped by resource tags.
 
 ## v1.5.2

--- a/modules/app-db-prereqs/main.tf
+++ b/modules/app-db-prereqs/main.tf
@@ -516,14 +516,9 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
         ]
         Condition = {
           StringEquals = {
-            "aws:RequestTag/AgentName" = each.key
-            "aws:RequestTag/ManagedBy" = local.managed_by_tag
-            "aws:RequestTag/Vpc"       = each.value.vpc_id
-          }
-          # Ownership values when present must be canonical. Without this,
-          # RdsTagOnCreate ORs with RdsAddTagsToManagedResources and bypasses
-          # the mutation-policy ownership check on the same action/resources.
-          StringEqualsIfExists = {
+            "aws:RequestTag/AgentName"         = each.key
+            "aws:RequestTag/ManagedBy"         = local.managed_by_tag
+            "aws:RequestTag/Vpc"               = each.value.vpc_id
             "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
             "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
           }
@@ -538,12 +533,14 @@ resource "aws_iam_policy" "lifecycle_worker_rds_provisioning" {
           local.rds_resources.snapshot,
         ]
         Condition = {
-          StringEqualsIfExists = {
-            "aws:RequestTag/AgentName"         = each.key
-            "aws:RequestTag/ManagedBy"         = local.managed_by_tag
-            "aws:RequestTag/Vpc"               = each.value.vpc_id
+          StringEquals = {
             "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
             "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
+          }
+          StringEqualsIfExists = {
+            "aws:RequestTag/AgentName" = each.key
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
         }
       },
@@ -706,16 +703,16 @@ resource "aws_iam_policy" "lifecycle_worker_rds_mutation" {
         ]
         Condition = {
           StringEquals = {
-            "aws:ResourceTag/AgentName" = each.key
-            "aws:ResourceTag/ManagedBy" = local.managed_by_tag
-            "aws:ResourceTag/Vpc"       = each.value.vpc_id
-          }
-          StringEqualsIfExists = {
-            "aws:RequestTag/AgentName"         = each.key
-            "aws:RequestTag/ManagedBy"         = local.managed_by_tag
-            "aws:RequestTag/Vpc"               = each.value.vpc_id
             "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
             "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
+            "aws:ResourceTag/AgentName"        = each.key
+            "aws:ResourceTag/ManagedBy"        = local.managed_by_tag
+            "aws:ResourceTag/Vpc"              = each.value.vpc_id
+          }
+          StringEqualsIfExists = {
+            "aws:RequestTag/AgentName" = each.key
+            "aws:RequestTag/ManagedBy" = local.managed_by_tag
+            "aws:RequestTag/Vpc"       = each.value.vpc_id
           }
         }
       },
@@ -836,14 +833,9 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           Resource = "${local.ec2_prefix}:security-group-rule/*"
           Condition = {
             StringEquals = {
-              "aws:RequestTag/AgentName" = each.key
-              "aws:RequestTag/ManagedBy" = local.managed_by_tag
-              "aws:RequestTag/Vpc"       = each.value.vpc_id
-            }
-            # Direct lifecycle configurations deployed before the ownership-tag
-            # contract may omit these tags. Preserve that compatibility while
-            # rejecting non-canonical values whenever either tag is supplied.
-            StringEqualsIfExists = {
+              "aws:RequestTag/AgentName"         = each.key
+              "aws:RequestTag/ManagedBy"         = local.managed_by_tag
+              "aws:RequestTag/Vpc"               = each.value.vpc_id
               "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
               "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
             }
@@ -885,21 +877,16 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           ]
           Condition = {
             StringEquals = {
-              "aws:RequestTag/AgentName" = each.key
-              "aws:RequestTag/ManagedBy" = local.managed_by_tag
-              "aws:RequestTag/Vpc"       = each.value.vpc_id
+              "aws:RequestTag/AgentName"         = each.key
+              "aws:RequestTag/ManagedBy"         = local.managed_by_tag
+              "aws:RequestTag/Vpc"               = each.value.vpc_id
+              "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
+              "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
               "ec2:CreateAction" = [
                 "AuthorizeSecurityGroupEgress",
                 "AuthorizeSecurityGroupIngress",
                 "CreateSecurityGroup",
               ]
-            }
-            # Same overlapping-Allow bypass as RdsTagOnCreate: without this,
-            # CreateTags on create can write non-canonical ownership values
-            # even though Ec2CreateTagsOnManagedResources checks them.
-            StringEqualsIfExists = {
-              "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
-              "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
             }
           }
         },
@@ -913,16 +900,16 @@ resource "aws_iam_policy" "lifecycle_worker_ec2_provisioning" {
           ]
           Condition = {
             StringEquals = {
-              "aws:ResourceTag/AgentName" = each.key
-              "aws:ResourceTag/ManagedBy" = local.managed_by_tag
-              "aws:ResourceTag/Vpc"       = each.value.vpc_id
-            }
-            StringEqualsIfExists = {
-              "aws:RequestTag/AgentName"         = each.key
-              "aws:RequestTag/ManagedBy"         = local.managed_by_tag
-              "aws:RequestTag/Vpc"               = each.value.vpc_id
               "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
               "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
+              "aws:ResourceTag/AgentName"        = each.key
+              "aws:ResourceTag/ManagedBy"        = local.managed_by_tag
+              "aws:ResourceTag/Vpc"              = each.value.vpc_id
+            }
+            StringEqualsIfExists = {
+              "aws:RequestTag/AgentName" = each.key
+              "aws:RequestTag/ManagedBy" = local.managed_by_tag
+              "aws:RequestTag/Vpc"       = each.value.vpc_id
             }
           }
         },
@@ -1142,7 +1129,7 @@ resource "aws_iam_policy" "lifecycle_worker_observability" {
         Action   = "logs:TagResource"
         Resource = local.app_db_cloudwatch_log_group_arn_patterns
         Condition = {
-          StringEqualsIfExists = {
+          StringEquals = {
             "aws:RequestTag/aws-apn-id"        = local.ownership_tags["aws-apn-id"]
             "aws:RequestTag/superblocks:owned" = local.ownership_tags["superblocks:owned"]
           }

--- a/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
+++ b/modules/app-db-prereqs/tests/agent_isolation.tftest.hcl
@@ -184,8 +184,8 @@ run "lifecycle_policies_require_matching_agent_name" {
   }
 
   # Every AddTags/CreateTags/TagResource Allow that can write ownership keys must
-  # require the canonical values when those keys appear in the request. Checking
-  # only one Sid leaves overlapping Allows that IAM ORs as a bypass.
+  # require the canonical values. Checking only one Sid leaves overlapping
+  # Allows that IAM ORs as a bypass.
   assert {
     condition = alltrue([
       for name in keys(var.agents) : alltrue(flatten([
@@ -194,25 +194,25 @@ run "lifecycle_policies_require_matching_agent_name" {
             jsondecode(aws_iam_policy.lifecycle_worker_rds_provisioning[name].policy).Statement,
             jsondecode(aws_iam_policy.lifecycle_worker_rds_mutation[name].policy).Statement,
             ) : (
-            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true" &&
-            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
+            try(statement.Condition.StringEquals["aws:RequestTag/superblocks:owned"], null) == "true" &&
+            try(statement.Condition.StringEquals["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
             ) if contains(try(tolist(statement.Action), [statement.Action]), "rds:AddTagsToResource")
         ],
         [
           for statement in jsondecode(aws_iam_policy.lifecycle_worker_ec2_provisioning[name].policy).Statement : (
-            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true" &&
-            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
+            try(statement.Condition.StringEquals["aws:RequestTag/superblocks:owned"], null) == "true" &&
+            try(statement.Condition.StringEquals["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
             ) if contains(try(tolist(statement.Action), [statement.Action]), "ec2:CreateTags")
         ],
         [
           for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability[name].policy).Statement : (
-            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true" &&
-            try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
+            try(statement.Condition.StringEquals["aws:RequestTag/superblocks:owned"], null) == "true" &&
+            try(statement.Condition.StringEquals["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
             ) if contains(try(tolist(statement.Action), [statement.Action]), "logs:TagResource")
         ],
       ]))
     ])
-    error_message = "Every AddTags/CreateTags/TagResource Allow must require canonical ownership values via StringEqualsIfExists — overlapping Allows must not bypass the check."
+    error_message = "Every AddTags/CreateTags/TagResource Allow must require canonical ownership values via StringEquals — overlapping Allows must not bypass the check."
   }
 
   assert {
@@ -251,8 +251,8 @@ run "lifecycle_policies_require_matching_agent_name" {
         try(statement.Condition.StringEquals["aws:RequestTag/AgentName"], null) == name &&
         try(statement.Condition.StringEquals["aws:RequestTag/ManagedBy"], null) == "superblocks-app-database-lifecycle" &&
         try(statement.Condition.StringEquals["aws:RequestTag/Vpc"], null) == var.agents[name].vpc_id &&
-        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
-        try(statement.Condition.StringEqualsIfExists["aws:RequestTag/superblocks:owned"], null) == "true"
+        try(statement.Condition.StringEquals["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f" &&
+        try(statement.Condition.StringEquals["aws:RequestTag/superblocks:owned"], null) == "true"
       ]) == 1
     ])
     error_message = "Security-group rule creates must authorize the new rule ARN from canonical request tags; resource tags do not exist yet."

--- a/modules/app-db-prereqs/tests/observability.tftest.hcl
+++ b/modules/app-db-prereqs/tests/observability.tftest.hcl
@@ -132,7 +132,7 @@ run "grants_app_database_observability_permissions" {
       for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
       try(tolist(statement.Action), [statement.Action]) if statement.Sid == "CloudWatchLogGroupsForAppDatabases"
     ]), "logs:TagResource")
-    error_message = "TagResource must not sit in the unconditional CloudWatch allow — ownership request-tag values need StringEqualsIfExists."
+    error_message = "TagResource must not sit in the unconditional CloudWatch allow — ownership request-tag values need StringEquals."
   }
 
   assert {
@@ -143,14 +143,14 @@ run "grants_app_database_observability_permissions" {
       ]) == "logs:TagResource" &&
       try(one([
         for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
-        statement.Condition.StringEqualsIfExists if statement.Sid == "CloudWatchTagResourceWithCanonicalOwnership"
+        statement.Condition.StringEquals if statement.Sid == "CloudWatchTagResourceWithCanonicalOwnership"
         ])["aws:RequestTag/superblocks:owned"], null) == "true" &&
       try(one([
         for statement in jsondecode(aws_iam_policy.lifecycle_worker_observability["opa1"].policy).Statement :
-        statement.Condition.StringEqualsIfExists if statement.Sid == "CloudWatchTagResourceWithCanonicalOwnership"
+        statement.Condition.StringEquals if statement.Sid == "CloudWatchTagResourceWithCanonicalOwnership"
         ])["aws:RequestTag/aws-apn-id"], null) == "pc:ctelqp437y3cvjkv5rv0z2w4f"
     )
-    error_message = "CloudWatch TagResource Allow must require canonical ownership values via StringEqualsIfExists."
+    error_message = "CloudWatch TagResource Allow must require canonical ownership values via StringEquals."
   }
 
   assert {


### PR DESCRIPTION
## Summary
- require canonical `aws-apn-id` and `superblocks:owned` request tags on every RDS, EC2, and CloudWatch tagging allow
- retain optional request scoping tags where AWS snapshot and mutation APIs may omit them
- strengthen policy tests so overlapping IAM allows cannot bypass ownership enforcement

## Test plan
- [x] `tofu test` in `modules/app-db-prereqs` (18 passed)
- [x] `tofu test` in `modules/app-db` (28 passed)

## Rollout dependency
Do not merge, release, or apply this PR until [orchestrator #2939](https://github.com/superblocksteam/orchestrator/pull/2939) is merged, all HQ App Database OPAs are redeployed, and provisioning is verified with the ownership tags.

Authored by a Cursor agent at David's request.

Made with [Cursor](https://cursor.com)